### PR TITLE
V lucet patch description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rsyncrosim
 Type: Package
-Title: The R Interface to SyncroSim: http://syncrosim.com/
+Title: The R Interface to SyncroSim
 Version: 1.1.10
 Author: ApexRMS <rsyncrosim@apexrms.com> and Josie Hughes <josie.hughes@canada.ca>
 Maintainer: ApexRMS <rsyncrosim@apexrms.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: The R Interface to SyncroSim
 Version: 1.1.10
 Author: ApexRMS <rsyncrosim@apexrms.com> and Josie Hughes <josie.hughes@canada.ca>
 Maintainer: ApexRMS <rsyncrosim@apexrms.com>
-Description: rsyncrosim provides an interface to SyncroSim, a generalized
+Description: This package provides an interface to SyncroSim, a generalized
     framework for managing scenario-based datasets. Simulation models can be added
     to SyncroSim in order to transform these datasets, taking advantage of general
     features such as defining scenarios of model inputs, running Monte Carlo


### PR DESCRIPTION
Running `R CMD check --as-cran` resulted in the following warnings:
```r
The Title field should be in title case. Current version is:
‘The R Interface to SyncroSim: http://syncrosim.com/’
In title case that is:
‘The R Interface to SyncroSim: Http://Syncrosim.com/’

The Description field should not start with the package name,
  'This package' or similar.
```
I am therefore interpreting that urls should not be in title of packages, and that we need to update the description field so that we pass the CRAN checks.