### PR TITLE
V lucet patch unused argument

### DIFF
--- a/R/breakpoint.R
+++ b/R/breakpoint.R
@@ -142,7 +142,7 @@ setMethod('setBreakpoints',signature(x="BreakpointSession"),function(x) {
 
 runJobParallel<- function(cPars) {
     ret = tryCatch({
-      cScn = scenario(.ssimLibrary(cPars$x,session=cPars$session,create=F),scenario=1)
+      cScn = scenario(.ssimLibrary(cPars$x,session=cPars$session),scenario=1)
       if(!exists("cScn")){
         stop("Problem with split-scenario: Can't find the library ",cPars$x,".")
       }

--- a/R/delete.R
+++ b/R/delete.R
@@ -34,7 +34,7 @@ setMethod('delete', signature(ssimObject="character"), function(ssimObject,proje
       return(SyncroSimNotFound())
     }
     
-    ssimObject=.ssimLibrary(ssimObject,create=F)
+    ssimObject=.ssimLibrary(ssimObject)
     return(delete(ssimObject,project,scenario,datasheet,force))
   }
 })

--- a/R/getFromXProjScn.R
+++ b/R/getFromXProjScn.R
@@ -10,7 +10,7 @@
   }
   
   if(class(ssimObject)=="character"){
-    ssimObject=.ssimLibrary(ssimObject,create=!complainIfMissing)
+    ssimObject=.ssimLibrary(ssimObject)
   }
   
   #Check for conflicts between ssimObject and project/scenario.

--- a/R/internalHelpers.R
+++ b/R/internalHelpers.R
@@ -86,7 +86,7 @@ getIdsFromListOfObjects<-function(ssimObject,expecting=NULL,scenario=NULL,projec
       stop("Expecting a list of ",expecting,"s.")
     }
   }
-  cLib=.ssimLibrary(ssimObject[[1]],create=F)
+  cLib=.ssimLibrary(ssimObject[[1]])
   if(!is.null(scenario)){
     warning("scenario argument is ignored when ssimObject is a list.")
   }
@@ -97,7 +97,7 @@ getIdsFromListOfObjects<-function(ssimObject,expecting=NULL,scenario=NULL,projec
   for(i in seq(length.out=length(ssimObject))){
     cObj = ssimObject[[i]]
     if(expecting=="character"){
-      cObj = .ssimLibrary(cObj,create=F)
+      cObj = .ssimLibrary(cObj)
     }
     
     if(class(cObj)!=expecting){

--- a/R/project.R
+++ b/R/project.R
@@ -257,15 +257,10 @@ project <- function(ssimObject=NULL,project=NULL,sourceProject=NULL,summary=NULL
     cRow = projectsToMake[i,]
     projExists = !is.na(cRow$exists)
     
-#    if (projExists){
-#      if(create){
-#        stop(paste0("Cannot overwrite existing project.  Use overwrite=T: ",cRow$name)) 
-#      }else if (overwrite){
-#        command(list(delete=NULL,project=NULL,lib=.filepath(ssimObject),pid=cRow$projectId,force=NULL),.session(ssimObject))
-#        allProjects[i, "exists"] <- NA
-#        projectsToMake[i, "exists"] <- NA        
-#      }
-    }
+  if (overwrite){
+    command(list(delete=NULL,project=NULL,lib=.filepath(ssimObject),pid=cRow$projectId,force=NULL),.session(ssimObject))
+    allProjects[i, "exists"] <- NA
+    projectsToMake[i, "exists"] <- NA        
   } 
   
   for(i in seq(length.out=nrow(projectsToMake))){

--- a/R/project.R
+++ b/R/project.R
@@ -204,9 +204,6 @@ project <- function(ssimObject=NULL,project=NULL,sourceProject=NULL,summary=NULL
   xProjScn  =.getFromXProjScn(ssimObject,project=project,scenario=NULL,convertObject=convertObject,returnIds=returnIds,goal="project",complainIfMissing=F)
   
   if(class(xProjScn)=="Project"){
-    if (create){
-      stop(paste0("Cannot overwrite existing project.  Use overwrite=T.",project)) 
-    }
     if (!overwrite){
       return(xProjScn)      
     }
@@ -260,14 +257,14 @@ project <- function(ssimObject=NULL,project=NULL,sourceProject=NULL,summary=NULL
     cRow = projectsToMake[i,]
     projExists = !is.na(cRow$exists)
     
-    if (projExists){
-      if(create){
-        stop(paste0("Cannot overwrite existing project.  Use overwrite=T: ",cRow$name)) 
-      }else if (overwrite){
-        command(list(delete=NULL,project=NULL,lib=.filepath(ssimObject),pid=cRow$projectId,force=NULL),.session(ssimObject))
-        allProjects[i, "exists"] <- NA
-        projectsToMake[i, "exists"] <- NA        
-      }
+#    if (projExists){
+#      if(create){
+#        stop(paste0("Cannot overwrite existing project.  Use overwrite=T: ",cRow$name)) 
+#      }else if (overwrite){
+#        command(list(delete=NULL,project=NULL,lib=.filepath(ssimObject),pid=cRow$projectId,force=NULL),.session(ssimObject))
+#        allProjects[i, "exists"] <- NA
+#        projectsToMake[i, "exists"] <- NA        
+#      }
     }
   } 
   

--- a/R/project.R
+++ b/R/project.R
@@ -161,7 +161,7 @@ setMethod(f='initialize',signature="Project",definition=function(.Object,ssimLib
 #' name(myProject) = "New project name"
 #' @name project
 #' @export
-project <- function(ssimObject=NULL,project=NULL,sourceProject=NULL,create=F,summary=NULL,forceElements=F,overwrite=F){
+project <- function(ssimObject=NULL,project=NULL,sourceProject=NULL,summary=NULL,forceElements=F,overwrite=F){
   
   if(create){
     warning("create argument deprecated and no longer required.")

--- a/R/project.R
+++ b/R/project.R
@@ -162,11 +162,6 @@ setMethod(f='initialize',signature="Project",definition=function(.Object,ssimLib
 #' @name project
 #' @export
 project <- function(ssimObject=NULL,project=NULL,sourceProject=NULL,summary=NULL,forceElements=F,overwrite=F){
-  
-  if(create){
-    warning("create argument deprecated and no longer required.")
-    if (overwrite){create=F}
-  } 
     
   if((class(ssimObject)=="character")&&(ssimObject==SyncroSimNotFound(warn=F))){
     return(SyncroSimNotFound())

--- a/R/run.R
+++ b/R/run.R
@@ -23,7 +23,7 @@ setGeneric('run',function(ssimObject,scenario=NULL,summary=F,jobs=1,transformerN
 #' @rdname run
 setMethod('run', signature(ssimObject="character"), function(ssimObject,scenario,summary,jobs,transformerName,forceElements) {
   if(ssimObject==SyncroSimNotFound(warn=F)){return(SyncroSimNotFound())}
-  ssimObject = .ssimLibrary(ssimObject,create=F)
+  ssimObject = .ssimLibrary(ssimObject)
   out = run(ssimObject,scenario,summary,jobs,transformerName,forceElements)
   return(out)
 })

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -191,9 +191,9 @@ scenario <- function(ssimObject=NULL,scenario=NULL,sourceScenario=NULL,summary=N
   xProjScn  =.getFromXProjScn(ssimObject,project=NULL,scenario=scenario,convertObject=convertObject,returnIds=returnIds,goal="scenario",complainIfMissing=F)
   
   if(class(xProjScn)=="Scenario"){
-    if (create){
-      stop(paste0("Cannot overwrite existing scenario.  Use overwrite=T.",project)) 
-    }
+#    if (create){
+#      stop(paste0("Cannot overwrite existing scenario.  Use overwrite=T.",project)) 
+#    }
     if (!overwrite){
       return(xProjScn)      
     }

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -191,9 +191,6 @@ scenario <- function(ssimObject=NULL,scenario=NULL,sourceScenario=NULL,summary=N
   xProjScn  =.getFromXProjScn(ssimObject,project=NULL,scenario=scenario,convertObject=convertObject,returnIds=returnIds,goal="scenario",complainIfMissing=F)
   
   if(class(xProjScn)=="Scenario"){
-#    if (create){
-#      stop(paste0("Cannot overwrite existing scenario.  Use overwrite=T.",project)) 
-#    }
     if (!overwrite){
       return(xProjScn)      
     }
@@ -285,9 +282,6 @@ scenario <- function(ssimObject=NULL,scenario=NULL,sourceScenario=NULL,summary=N
   for(i in seq(length.out=nrow(scnsToMake))){
     cRow = scnsToMake[i,]
     if(!is.na(cRow$exists)){
-      if (create){
-        stop(paste0("Cannot overwrite existing scenario: Use overwrite=T: ",cRow$name)) 
-      }
       scnList[[as.character(scnsToMake$scenarioId[i])]]=new("Scenario",ssimObject,project=cRow$projectId,id=cRow$scenarioId,scenarios=cRow)
     }else{
       obj=new("Scenario",ssimObject,project=cRow$projectId,name=cRow$name,sourceScenario=sourceScenario,scenarios=libScns)

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -147,12 +147,7 @@ setMethod(f='initialize',signature="Scenario",
 #' myScenario = scenario(myProject,scenario="a scenario",overwrite=T)
 #' @name scenario
 #' @export
-scenario <- function(ssimObject=NULL,scenario=NULL,sourceScenario=NULL,create=F,summary=NULL,results=F,forceElements=F,overwrite=F){
-  
-  if(create){
-    warning("create argument deprecated and no longer required.")
-    if (overwrite){create=F}
-  } 
+scenario <- function(ssimObject=NULL,scenario=NULL,sourceScenario=NULL,summary=NULL,results=F,forceElements=F,overwrite=F){ 
   
   if(is.character(ssimObject)&&(ssimObject==SyncroSimNotFound(warn=F))){
     return(SyncroSimNotFound())

--- a/R/ssimLibrary.R
+++ b/R/ssimLibrary.R
@@ -4,12 +4,7 @@
 NULL
 
 setMethod(f='initialize',signature="SsimLibrary",
-    definition=function(.Object,name=NULL,create=F,package=NULL,session=NULL,addon=NULL,forceUpdate=F,overwrite=F){
-      
-    if(create){
-      warning("create argument deprecated and no longer required.")
-      if (overwrite){create=F}
-    } 
+    definition=function(.Object,name=NULL,package=NULL,session=NULL,addon=NULL,forceUpdate=F,overwrite=F){
       
     enabled=NULL
     
@@ -60,12 +55,6 @@ setMethod(f='initialize',signature="SsimLibrary",
     
     if(!grepl(".ssim",path)) {
       path=paste0(path,".ssim")
-    }
-    
-    if (create) {
-      if (file.exists(path)) {
-        stop(paste0("Cannot overwrite existing library.  Use overwrite=T: ",path)) 
-      }
     }
     
     if (overwrite){
@@ -169,18 +158,18 @@ setMethod(f='initialize',signature="SsimLibrary",
   }
 )
 
-setGeneric('.ssimLibrary', function(name=NULL,create=F,package=NULL,session=NULL,addon=NULL,forceUpdate=F,overwrite=F) standardGeneric('.ssimLibrary'))
+setGeneric('.ssimLibrary', function(name=NULL,package=NULL,session=NULL,addon=NULL,forceUpdate=F,overwrite=F) standardGeneric('.ssimLibrary'))
 
-setMethod('.ssimLibrary',signature(name="missingOrNULLOrChar"),function(name,create,package,session,addon,forceUpdate,overwrite=F) {
-  return(new("SsimLibrary",name,create,package,session,addon,forceUpdate))
+setMethod('.ssimLibrary',signature(name="missingOrNULLOrChar"),function(name,package,session,addon,forceUpdate,overwrite=F) {
+  return(new("SsimLibrary",name,package,session,addon,forceUpdate))
 })
 
-setMethod('.ssimLibrary', signature(name="SsimObject"), function(name,create,package,session,addon,forceUpdate,overwrite) {
+setMethod('.ssimLibrary', signature(name="SsimObject"), function(name,package,session,addon,forceUpdate,overwrite) {
   
   if(class(name)=="SsimLibrary"){
     out=name
   }else{
-    out = .ssimLibrary(name=.filepath(name),create,package,session=.session(name),addon,forceUpdate,overwrite)
+    out = .ssimLibrary(name=.filepath(name),package,session=.session(name),addon,forceUpdate,overwrite)
   }
   return(out)
 })
@@ -223,16 +212,16 @@ setMethod('.ssimLibrary', signature(name="SsimObject"), function(name,create,pac
 #' filepath(myLibrary)
 #' info(myLibrary)
 #' @export
-setGeneric('ssimLibrary',function(name=NULL,create=F,summary=NULL,package=NULL,session=NULL,addon=NULL,forceUpdate=F,overwrite=F) standardGeneric('ssimLibrary'))
+setGeneric('ssimLibrary',function(name=NULL,summary=NULL,package=NULL,session=NULL,addon=NULL,forceUpdate=F,overwrite=F) standardGeneric('ssimLibrary'))
 
 #' @rdname ssimLibrary
-setMethod('ssimLibrary', signature(name="SsimObject"), function(name,create,summary,package,session,addon,forceUpdate,overwrite) {
+setMethod('ssimLibrary', signature(name="SsimObject"), function(name,summary,package,session,addon,forceUpdate,overwrite) {
   
   if(class(name)=="SsimLibrary"){
     out=name
     if(is.null(summary)){summary=T}
   }else{
-    out = .ssimLibrary(name=.filepath(name),create,package,session=.session(name),addon,forceUpdate,overwrite)
+    out = .ssimLibrary(name=.filepath(name),package,session=.session(name),addon,forceUpdate,overwrite)
     if(is.null(summary)){summary=F}
   }
   if(!summary){
@@ -242,14 +231,14 @@ setMethod('ssimLibrary', signature(name="SsimObject"), function(name,create,summ
 })
 
 #' @rdname ssimLibrary
-setMethod('ssimLibrary',signature(name="missingOrNULLOrChar"),function(name=NULL,create,summary=NULL,package,session,addon,forceUpdate,overwrite) {
+setMethod('ssimLibrary',signature(name="missingOrNULLOrChar"),function(name=NULL,summary=NULL,package,session,addon,forceUpdate,overwrite) {
   
     if(is.null(session)){session=.session()}
     if((class(session)=="character")&&(session==SyncroSimNotFound(warn=F))){
       return(SyncroSimNotFound())
     }
             
-    newLib = new("SsimLibrary",name,create,package,session,addon,forceUpdate,overwrite)
+    newLib = new("SsimLibrary",name,package,session,addon,forceUpdate,overwrite)
     if(!is.null(summary)&&summary){
       return(info(newLib))
     }


### PR DESCRIPTION
Here is a pull request for the removal of the `create` argument, as step that @colindaniel and I have been talking about taking. I have edited the code here to the best of my understanding, removing things when I think is appropriate. 

Also, is there something to do change here with the `overwrite` argument?  