### PR TITLE
Fix cran comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsyncrosim
 Type: Package
 Title: The R Interface to SyncroSim
-Version: 1.2
+Version: 1.2.1
 Authors@R: c(
     person("Colin", "Daniel", email = "colin.daniel@apexrms.com",
            role = c("aut", "cre")),
@@ -12,7 +12,7 @@ Authors@R: c(
     person("Leonardo", "Frid", 
            role = "aut"), 
     person("Valentin", "Lucet", 
-           role = "ctb"),
+           role = "aut"),
     person("ApexRMS", role="cph"))
 Description: 'SyncroSim' is a generalized framework for managing scenario-based 
     datasets (<https://syncrosim.com/>). 'rsyncrosim' provides an interface to 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,5 +89,5 @@ Collate:
     'version.R'
 RoxygenNote: 7.1.0
 VignetteBuilder: knitr
-URL: <https://github.com/syncrosim/rsyncrosim>
-BugReports: <https://github.com/syncrosim/rsyncrosim/issues>
+URL: https://github.com/syncrosim/rsyncrosim
+BugReports: https://github.com/syncrosim/rsyncrosim/issues

--- a/R/addModule.R
+++ b/R/addModule.R
@@ -10,6 +10,7 @@ NULL
 #'
 #' @param filename Character string or vector of these. The path to an .ssimpkg file on disk, or a vector of filepaths.
 #' @param session Session.
+#' 
 setGeneric("addModule", function(filename, session = NULL) standardGeneric("addModule"))
 
 #' @rdname addModule

--- a/R/addPackage.R
+++ b/R/addPackage.R
@@ -5,10 +5,16 @@ NULL
 
 #' Adds a package to SyncroSim
 #'
-#' Adds a package to SyncroSim.
+#' Adds a package to SyncroSim. This functions will query the syncrosim 
+#' package server for the package name provided as input.
 #'
-#' @param name Character string.  The name of the package to install from the online package server.
+#' @param name Character string.  The name of the package to install.
 #' @param session Session.
+#' 
+#' @return 
+#' This function will inivisibly return `TRUE` upon success (i.e.successful 
+#' install) and `FALSE` upon failure.
+#' 
 #' @export
 setGeneric("addPackage", function(name, session = NULL) standardGeneric("addPackage"))
 
@@ -25,8 +31,10 @@ setMethod("addPackage", signature(session = "missingOrNULL"), function(name, ses
 
 #' @rdname addPackage
 setMethod("addPackage", signature(session = "Session"), function(name, session) {
+  success <- FALSE
+  
   if (is.null(name)) {
-    stop("A package name is required.")
+    stop("A package name is required")
   }
 
   packages <- package(session)
@@ -36,8 +44,10 @@ setMethod("addPackage", signature(session = "Session"), function(name, session) 
   } else {
     tt <- command(args = list(install = name), session, program = "SyncroSim.PackageManager.exe")
     if (tt == "saved"){
-      tt <- paste0("Package <", name, "> installed.")
+      tt <- paste0("Package <", name, "> installed")
+      success <- TRUE
     }
   }
   message(tt)
+  return(invisible(success))
 })

--- a/R/addPackageFile.R
+++ b/R/addPackageFile.R
@@ -5,10 +5,15 @@ NULL
 
 #' Adds a package to SyncroSim
 #'
-#' Adds a package to SyncroSim
+#' Adds a package to SyncroSim from a package file.
 #'
 #' @param filename Character string.  The path to a SyncroSim package file.
 #' @param session Session.
+#' 
+#' @return 
+#' This function invisibly returns `TRUE` upon success (i.e.successful 
+#' install) and `FALSE` upon failure.
+#' 
 #' @export
 setGeneric("addPackageFile", function(filename, session = NULL) standardGeneric("addPackageFile"))
 
@@ -25,14 +30,21 @@ setMethod("addPackageFile", signature(session = "missingOrNULL"), function(filen
 
 #' @rdname addPackageFile
 setMethod("addPackageFile", signature(session = "Session"), function(filename, session) {
+  success <- FALSE
+  
   if (is.null(filename)) {
-    stop("A file name is required.")
+    stop("A file name is required")
   }
-
+  
   if (!file.exists(filename)) {
-    stop(paste0("Cannot find file: ", filename))
+    tt <- paste0("Cannot find file: ", filename)
+  } else{
+    tt <- command(args = list(finstall = filename), session, program = "SyncroSim.PackageManager.exe")
+    if (tt == "saved"){
+      success <- TRUE
+      tt <- paste0("Package installed from file <", filename, ">")
+    }
   }
-
-  tt <- command(args = list(finstall = filename), session, program = "SyncroSim.PackageManager.exe")
   message(tt)
+  return(invisible(success))
 })

--- a/R/addRow.R
+++ b/R/addRow.R
@@ -15,7 +15,10 @@ NULL
 #'
 #' @param targetDataframe Dataframe.
 #' @param value Dataframe, character string vector, or list. Columns in value should be a subset of columns in targetDataframe.
-#' @return A dataframe with new rows.
+#' 
+#' @return 
+#' A dataframe with new rows.
+#' 
 #' @export
 setGeneric("addRow", function(targetDataframe, value) standardGeneric("addRow"))
 

--- a/R/addon.R
+++ b/R/addon.R
@@ -6,13 +6,17 @@ NULL
 #' addon(s) of an SsimLibrary or Session
 #'
 #' The addon(s) of an SsimLibrary or Session.
-#'
+#' 
 #' @param ssimObject SsimLibrary/Project/Scenario or Session.
-#' @return A dataframe of addons.
+#' 
+#' @return 
+#' A dataframe of addons.
+#' 
 #' @examples
 #' \donttest{
 #' addon(ssimLibrary(name = "mylib"))
 #' }
+#' 
 #' @export
 setGeneric("addon", function(ssimObject) standardGeneric("addon"))
 

--- a/R/backup.R
+++ b/R/backup.R
@@ -8,6 +8,11 @@ NULL
 #' Backup an SsimLibrary.
 #'
 #' @param ssimObject SsimLibrary/Project/Scenario.
+#' 
+#' @return 
+#' This function inivisibly returns `TRUE` upon success (i.e.successful 
+#' backup) and `FALSE` upon failure.
+#' 
 #' @export
 setGeneric("backup", function(ssimObject) standardGeneric("backup"))
 
@@ -18,6 +23,7 @@ setMethod("backup", signature(ssimObject = "character"), function(ssimObject) {
 
 #' @rdname backup
 setMethod("backup", signature(ssimObject = "SsimObject"), function(ssimObject) {
+  success <- FALSE
   ds <- datasheet(ssimObject, name = "core_Backup")
   args <- list(lib = .filepath(ssimObject), backup = NULL)
 
@@ -34,5 +40,11 @@ setMethod("backup", signature(ssimObject = "SsimObject"), function(ssimObject) {
   }
 
   tt <- command(args = args, session = .session(ssimObject))
-  return(tt)
+  message(tt)
+  if (tt == "Backup complete."){
+    success <- TRUE
+  } else {
+    success <- FALSE
+  }
+  return(invisible(success))
 })

--- a/R/basePackage.R
+++ b/R/basePackage.R
@@ -8,7 +8,10 @@ NULL
 #' Base packages installed with this version of SyncroSim
 #'
 #' @param ssimObject Session or SsimLibrary.
-#' @return A dataframe of base packages (for Session) or named vector of character strings (for SsimLibrary)
+#' 
+#' @return 
+#' A dataframe of base packages (for Session) or named vector of character strings (for SsimLibrary)
+#' 
 #' @export
 setGeneric("basePackage", function(ssimObject = NULL) standardGeneric("basePackage"))
 #' @rdname basePackage

--- a/R/breakpoint.R
+++ b/R/breakpoint.R
@@ -204,8 +204,11 @@ getBPNameLongForm <- function(breakpointType) {
 #' @param breakpointType bi: before iteration; ai: after iteration; bt:before timestep; at: after timestep
 #' @param arguments A vector of timesteps or iterations e.g. c(1,2)
 #' @param callback A function to be called when the breakpoint is hit
+#' 
 #' @return A SyncroSim Scenario with an updated list of breakpoints
+#' 
 #' @details Breakpoints are only supported for Stochastic Time Transformers.
+#' 
 #' @examples
 #' \donttest{
 #' callbackFunction <- function(x, iteration, timestep) {
@@ -241,7 +244,9 @@ setMethod("addBreakpoint", signature(x = "Scenario"), function(x, transformerNam
 #' @param x A SyncroSim Scenario
 #' @param transformerName A Stochastic Time Transformer (e.g. stsim_Runtime).  Optional.
 #' @param breakpointType bi: before iteration; ai: after iteration; bt:before timestep; at: after timestep.  Optional.
+#' 
 #' @return A SyncroSim Scenario with an updated list of breakpoints
+#' 
 #' @examples
 #' \donttest{
 #' myScenario <- deleteBreakpoint(myScenario)
@@ -286,6 +291,10 @@ setMethod("deleteBreakpoint", signature(x = "Scenario"), function(x, transformer
 #' Lists the breakpoints for a Scenario.
 #'
 #' @param x A SyncroSim Scenario
+#' 
+#' @return 
+#' Does not return anything, used for printing purposes.
+#' 
 #' @export
 setGeneric("breakpoint", function(x) standardGeneric("breakpoint"))
 

--- a/R/command.R
+++ b/R/command.R
@@ -14,12 +14,17 @@ NULL
 #'    \item Named list or named vector e.g. list(name1=NULL,name2=value2): "--name1 --name2=value2"
 #'    \item Unnamed list or unnamed vector e.g. c("create","help"): "--create --help"
 #' }
+#' 
 #' @param args Character string, named list, named vector, unnamed list, or unnamed vector. Arguments for the SyncroSim console. See details.
 #' @param session Session. If NULL, a default session will be used.
 #' @param program Character. The name of the target SyncroSim executable. Options include SyncroSim.Console.exe (default), SyncroSim.Server.exe, SyncroSim.PackageManager.exe and SyncroSim.Multiband.exe.
 #' @param wait Logical. If TRUE (default) R will wait for the command to finish before proceeding. Note that silent(session) is ignored if wait=FALSE.
-#' @return Output from the SyncroSim program.
+#' 
+#' @return 
+#' A chracter string, output from the SyncroSim program.
+#' 
 #' @examples
+#' \donttest{
 #' # Use a default session to create a new library in the current working directory.
 #' args <- list(create = NULL, library = NULL, name = paste0(getwd(), "/temp.ssim"), package = "stsim")
 #' output <- command(args, session = session(printCmd = TRUE))
@@ -29,6 +34,7 @@ NULL
 #' command(c("create", "help"))
 #' command("--create --help")
 #' command(list(create = NULL, help = NULL))
+#' }
 #' @export
 command <- function(args, session = NULL, program = "SyncroSim.Console.exe", wait = TRUE) {
 

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -5,7 +5,7 @@ NULL
 
 #' Get a datasheet
 #'
-#' Gets SyncroSim datasheet.
+#' Retrieves a SyncroSim datasheet.
 #'
 #' @details
 #'
@@ -38,7 +38,10 @@ NULL
 #' @param includeKey Logical. If TRUE include primary key in table.
 #' @param forceElements Logical. If FALSE and name has a single element returns a dataframe; otherwise a list of dataframes. Ignored if summary=TRUE.
 #' @param fastQuery Logical.  If TRUE, the request is optimized for performance.  Ignored if combined with summary, empty, or sqlStatement flags.
-#' @return If summary=TRUE returns a dataframe of datasheet names and other info, otherwise returns a dataframe or list of these.
+#' 
+#' @return 
+#' If summary=TRUE returns a dataframe of datasheet names and other info, otherwise returns a dataframe or list of these.
+#' 
 #' @export
 #' @import RSQLite
 setGeneric("datasheet", function(ssimObject, name = NULL, project = NULL, scenario = NULL, summary = NULL, optional = FALSE, empty = FALSE, lookupsAsFactors = TRUE, sqlStatement = list(select = "SELECT *", groupBy = ""), includeKey = FALSE, forceElements = FALSE, fastQuery = FALSE) standardGeneric("datasheet"))

--- a/R/datasheetRaster.R
+++ b/R/datasheetRaster.R
@@ -8,13 +8,6 @@ NULL
 #' Get spatial inputs or outputs from one or more SyncroSim scenarios.
 #' @details
 #'
-# Off for v0.1
-# The Color column of a rat table should have one of these formats:
-# \itemize{
-#   \item {R,G,B,alpha: } {4 numbers representing red, green, blue and alpha, separated by commas, and scaled between 0 and 255. See rgb() for details.}
-#   \item {R colour names: } {See colors() for options.}
-#   \item {hexadecimal colors: } {As returned by R functions such as rainbow(), heat.colors(), terrain.colors(), topo.colors(), gray(), etc.}
-# }
 #'
 #' The names() of the returned raster stack contain metadata.
 #' For datasheets without Filename this is: paste0(<datasheet name>,".Scn",<scenario id>,".",<tif name>)
@@ -28,7 +21,10 @@ NULL
 #' @param timestep integer, character string, or vector of integer/character string. Timestep(s) to include. If NULL then all timesteps are included.  If no Timestep column in the datasheet, then ignored.
 #' @param subset logical expression. logical expression indicating datasheet rows to return. e.g. expression(grepl("Ts0001",Filename,fixed=T)). See subset() for details.
 #' @param forceElements logical. If TRUE then returns a single raster as a RasterStack; otherwise returns a single raster as a RasterLayer directly.
-#' @return A RasterLayer, RasterStack or RasterBrick object. See raster package documentation for details.
+#' 
+#' @return 
+#' A RasterLayer, RasterStack or RasterBrick object. See raster package documentation for details.
+#' 
 #' @examples
 #' \donttest{
 #' datasheetRaster(myResult,
@@ -36,6 +32,7 @@ NULL
 #'   subset = expression(grepl("Ts0001", Filename, fixed = T))
 #' )
 #' }
+#' 
 #' @export
 setGeneric("datasheetRaster", function(ssimObject, datasheet, column = NULL, scenario = NULL, iteration = NULL, timestep = NULL, subset = NULL, forceElements = F) standardGeneric("datasheetRaster"))
 

--- a/R/dateModified.R
+++ b/R/dateModified.R
@@ -8,6 +8,11 @@ NULL
 #' The most recent modification date of an SsimLibrary/Project/Scenario
 #'
 #' @param ssimObject SsimLibrary/Project/Scenario.
+#' 
+#' @return 
+#' A character string of the date and time of the most recent modification 
+#' to the ssimObject provided as input.
+#' 
 #' @export
 setGeneric("dateModified", function(ssimObject) standardGeneric("dateModified"))
 

--- a/R/deleteModule.R
+++ b/R/deleteModule.R
@@ -10,7 +10,9 @@ NULL
 #' @param name Character string or vector of these. A module or vector of modules to remove. See modules() for options.
 #' @param session Session.
 #' @param force logical. If T, delete without requiring confirmation from user.
+#' 
 #' @return "saved" or error message.
+#' 
 #' @export
 setGeneric("deleteModule", function(name, session = NULL, force = F) standardGeneric("deleteModule"))
 

--- a/R/deletePackage.R
+++ b/R/deletePackage.R
@@ -5,13 +5,18 @@ NULL
 
 #' Deletes a package
 #'
-#' Deletes a package.
+#' Deletes a package from your syncrosim instalation.
+#' 
 #' @param name Character. The name of the package to delete.
 #' @param session Session.
 #' @param force logical. If T, delete without requiring confirmation from user.
-#' @return "saved" or error message.
+#' 
+#' @return 
+#' This function invisibly returns `TRUE` upon success (i.e.successful 
+#' deletion) and `FALSE` upon failure.
+#' 
 #' @export
-setGeneric("deletePackage", function(name, session = NULL, force = F) standardGeneric("deletePackage"))
+setGeneric("deletePackage", function(name, session = NULL, force = FALSE) standardGeneric("deletePackage"))
 
 #' @rdname deletePackage
 setMethod("deletePackage", signature(session = "character"), function(name, session, force) {
@@ -27,6 +32,7 @@ setMethod("deletePackage", signature(session = "missingOrNULL"), function(name, 
 #' @rdname deletePackage
 setMethod("deletePackage", signature(session = "Session"), function(name, session, force) {
   installed <- package(session)
+  success <- FALSE
 
   if (!is.element(name, installed$name)) {
     stop("The package is not installed.")
@@ -40,8 +46,13 @@ setMethod("deletePackage", signature(session = "Session"), function(name, sessio
 
   if (answer == "y") {
     tt <- command(args = list(uninstall = name), session, program = "SyncroSim.PackageManager.exe")
-    return(tt)
+    if (tt == "saved"){
+      tt <- paste0("Package <", name,"> deleted")
+      success <- TRUE
+    } 
   } else {
-    return(NULL)
+    tt <- paste0("Deletion of package <", name,"> skipped")
   }
+  message(tt)
+  return(invisible(success))
 })

--- a/R/description.R
+++ b/R/description.R
@@ -8,6 +8,10 @@ NULL
 #' The description of an SsimLibrary/ProjectScenario.
 #'
 #' @param ssimObject SsimLibrary/Project/Scenario.
+#' 
+#' @return
+#' A character string describing the ssimObject.
+#' 
 #' @export
 setGeneric("description", function(ssimObject) standardGeneric("description"))
 
@@ -17,6 +21,10 @@ setGeneric("description", function(ssimObject) standardGeneric("description"))
 #'
 #' @param ssimObject Scenario/Project/SsimLibrary
 #' @param value The new description.
+#' 
+#' @return
+#' The object with updated description.
+#' 
 #' @export
 setGeneric("description<-", function(ssimObject, value) standardGeneric("description<-"))
 

--- a/R/disableAddon.R
+++ b/R/disableAddon.R
@@ -9,15 +9,20 @@ NULL
 #'
 #' @param ssimLibrary SsimLibrary
 #' @param name Character string or vector of addon names
-#' @return Character "saved" in case of success or error message.
+#' 
+#' @return
+#' This function invisibly returns `TRUE` upon success (i.e.successful deactivation of the addon 
+#' and `FALSE` upon failure.
+#' 
 #' @examples
+#' \donttest{
 #' myLibrary <- ssimLibrary("mylib")
 #' enableAddon(myLibrary, c("stsimecodep"))
 #' addon(myLibrary)
-#' \donttest{
 #' disableAddon(myLibrary, c("stsimecodep"))
-#' }
 #' addon(myLibrary)
+#' }
+#' 
 #' @export
 setGeneric("disableAddon", function(ssimLibrary, name) standardGeneric("disableAddon"))
 
@@ -36,17 +41,25 @@ setMethod("disableAddon", signature(ssimLibrary = "SsimLibrary"), function(ssimL
     cVal <- name[i]
     if (!is.element(cVal, cAdds$name)) {
       print(paste0("Warning - ", cVal, " is not among the available addons: ", paste(cAdds$name[cAdds$enabled == "No"], collapse = ",")))
+      retList[[cVal]] <- FALSE
       next
     }
     cAddsLess <- subset(cAdds, enabled == T)
     if (!is.element(cVal, cAddsLess$name)) {
-      print(paste0(cVal, " is already disabled."))
+      message(paste0(cVal, " is already disabled."))
+      retList[[cVal]] <- FALSE
       next
     }
 
     tt <- command(list(delete = NULL, addon = NULL, force = NULL, lib = .filepath(ssimLibrary), name = cVal), .session(ssimLibrary))
-    retList[[cVal]] <- tt
+    if (tt == "saved"){
+      message(paste0("Addon <", cVal, "> disabled"))
+      retList[[cVal]] <- TRUE
+    } else {
+      message(tt)
+      retList[[cVal]] <- FALSE
+    }
   }
 
-  return(retList)
+  return(invisible(retList))
 })

--- a/R/enableAddon.R
+++ b/R/enableAddon.R
@@ -9,7 +9,11 @@ NULL
 #'
 #' @param ssimLibrary SsimLibrary
 #' @param name Character string or vector of addon names
-#' @return Character "saved" in case of success or error message.
+#' 
+#' @return
+#' This function invisibly returns `TRUE` upon success (i.e.successful activation of the addon 
+#' and `FALSE` upon failure.
+#' 
 #' @examples
 #' \donttest{
 #' myLibrary <- ssimLibrary()
@@ -18,6 +22,7 @@ NULL
 #' disableAddon(myLibrary, c("stsim-ecological-departure"))
 #' addon(myLibrary)
 #' }
+#' 
 #' @export
 setGeneric("enableAddon", function(ssimLibrary, name) standardGeneric("enableAddon"))
 
@@ -35,17 +40,25 @@ setMethod("enableAddon", signature(ssimLibrary = "SsimLibrary"), function(ssimLi
     cVal <- name[i]
     if (!is.element(cVal, cAdds$name)) {
       print(paste0("Warning - ", cVal, " is not among the available addons: ", paste(cAdds$name[cAdds$enabled == "No"], collapse = ",")))
+      retList[[cVal]] <- FALSE
       next
     }
     cAddsLess <- subset(cAdds, enabled == F)
     if (!is.element(cVal, cAddsLess$name)) {
-      print(paste0(cVal, " is already enabled."))
+      message(paste0(cVal, " is already enabled."))
+      retList[[cVal]] <- FALSE
       next
     }
 
     tt <- command(list(create = NULL, addon = NULL, lib = .filepath(ssimLibrary), name = cVal), .session(ssimLibrary))
-    retList[[cVal]] <- tt
+    if (tt == "saved"){
+      message(paste0("Addon <", cVal, "> enabled"))
+      retList[[cVal]] <- TRUE
+    } else {
+      message(tt)
+      retList[[cVal]] <- FALSE
+    }
   }
 
-  return(retList)
+  return(invisible(retList))
 })

--- a/R/filepath.R
+++ b/R/filepath.R
@@ -8,6 +8,10 @@ NULL
 #' The path to a SyncroSim Session, SSimLibarary, Project or Scenario on disk.
 #'
 #' @param ssimObject An object containing a filepath.
+#' 
+#' @return 
+#' A character string: the path to a SyncroSim object on disk.
+#' 
 #' @export
 setGeneric("filepath", function(ssimObject) standardGeneric("filepath"))
 

--- a/R/internalHelpers.R
+++ b/R/internalHelpers.R
@@ -160,7 +160,6 @@ camel <- function(x) {
 }
 
 # http://stackoverflow.com/questions/26083625/how-do-you-include-data-frame-output-inside-warnings-and-errors
-# @export
 printAndCapture <- function(x) {
   paste(capture.output(print(x)), collapse = "\n")
 }
@@ -182,7 +181,7 @@ printAndCapture <- function(x) {
 # @return A data frame of output from the SyncroSim console.
 # @examples
 # # Use a default session to create a new library
-# myArgs = list(list=NULL,columns=NULL,lib="C:/Temp/NewLibrary.ssim",sheet="stsim_Stratum",pid=1)
+# myArgs = list(list=NULL,columns=NULL,lib=".",sheet="stsim_Stratum",pid=1)
 # myOutput = command(args=myArgs,mySsim)
 # myDataframe = dataframeFromSSim(myOutput)
 # myDataframe

--- a/R/internalWrappers.R
+++ b/R/internalWrappers.R
@@ -15,7 +15,7 @@ NULL
 #' @include filepath.R
 #' @include addon.R
 #' @include datasheet.R
-#' @include datasheets.R
+#' @include internalHelpers.R
 #' @include name.R
 NULL
 # @export

--- a/R/mergeDependencies.R
+++ b/R/mergeDependencies.R
@@ -5,10 +5,14 @@ NULL
 
 #' Merge Dependencies for a Scenario.
 #'
-#' Whether or not a Scenario is configured to merge dependencies at run time.
+#' Retrieves whether or not a Scenario is configured to merge dependencies at run time.
 #'
 #' @param ssimObject Scenario
-#' @return logical.
+#' 
+#' @return 
+#' Returns a logical: `TRUE` is the scenario is configured to merge dependencies at run time, 
+#' and `FALSE` otherwise.
+#' 
 #' @export
 setGeneric("mergeDependencies", function(ssimObject) standardGeneric("mergeDependencies"))
 
@@ -20,15 +24,24 @@ setMethod("mergeDependencies", signature(ssimObject = "character"), function(ssi
 #' @rdname mergeDependencies
 setMethod("mergeDependencies", signature(ssimObject = "Scenario"), function(ssimObject) {
   scnInfo <- scenario(ssimObject, summary = T)
-  return(scnInfo$mergeDependencies)
+  if (scnInfo$mergeDependencies == "Yes"){
+    value <- TRUE
+  } else if (scnInfo$mergeDependencies == "No"){
+    value <- FALSE
+  }
+  return(value)
 })
 
 #' Merge Dependencies for a Scenario.
 #'
-#' Whether or not a Scenario is configured to merge dependencies at run time.
+#' Sets whether or not a Scenario is configured to merge dependencies at run time.
 #'
 #' @param ssimObject Scenario
 #' @param value Logical. If T the Scenario will be set to merge dependencies at runtime.
+#' 
+#' @return 
+#' The updated ssimObject.
+#' 
 #' @export
 setGeneric("mergeDependencies<-", function(ssimObject, value) standardGeneric("mergeDependencies<-"))
 

--- a/R/model.R
+++ b/R/model.R
@@ -8,7 +8,10 @@ NULL
 #' Deprecated.  See: \code{\link{package}}
 #'
 #' @param ssimObject Session or SsimLibrary.
-#' @return A dataframe of models (for Session) or named vector of character strings (for SsimLibrary)
+#' 
+#' @return 
+#' A dataframe of models (for Session) or named vector of character strings (for SsimLibrary)
+#' 
 #' @export
 setGeneric("model", function(ssimObject = NULL) standardGeneric("model"))
 

--- a/R/module.R
+++ b/R/module.R
@@ -8,7 +8,10 @@ NULL
 #' Deprecated.  See: \code{\link{package}}
 #'
 #' @param session Session.
-#' @return A dataframe of modules
+#' 
+#' @return 
+#' A dataframe of modules.
+#' 
 #' @export
 setGeneric("module", function(session) standardGeneric("module"))
 

--- a/R/name.R
+++ b/R/name.R
@@ -5,10 +5,13 @@ NULL
 
 #' The name of a SyncroSim library, project or scenario.
 #'
-#' The name of an SsimLibrary, Project or Scenario.
+#' Retrieves the name of an SsimLibrary, Project or Scenario.
 #'
 #' @param ssimObject SsimLibrary, Project, or Scenario.
-#' @return Character string
+#' 
+#' @return 
+#' Character string: the name of the ssimObject.
+#' 
 #' @export
 setGeneric("name", function(ssimObject) standardGeneric("name"))
 
@@ -42,7 +45,10 @@ setMethod("name", signature(ssimObject = "Project"), function(ssimObject) {
 #' Set the name of a SyncroSim Project, Scenario or Library
 #'
 #' @param ssimObject Scenario/Project/SsimLibrary
-#' @param value The new name.
+#' 
+#' @param value 
+#' The updated ssimObject. 
+#' 
 #' @export
 setGeneric("name<-", function(ssimObject, value) standardGeneric("name<-"))
 

--- a/R/owner.R
+++ b/R/owner.R
@@ -5,9 +5,13 @@ NULL
 
 #' The owner of a SsimLibrary/Project/Scenario.
 #'
-#' The owner of an SsimLibrary/ProjectScenario
+#' Retrieves the owner of an SsimLibrary/ProjectScenario
 #'
 #' @param ssimObject SsimLibrary/Project/Scenario.
+#' 
+#' @return 
+#' A character string: the owner of the ssimObject. 
+#' 
 #' @export
 setGeneric("owner", function(ssimObject) standardGeneric("owner"))
 
@@ -17,6 +21,10 @@ setGeneric("owner", function(ssimObject) standardGeneric("owner"))
 #'
 #' @param ssimObject Scenario/Project/SsimLibrary
 #' @param value The new owner.
+#' 
+#' @return 
+#' The updated ssimObject.
+#' 
 #' @export
 setGeneric("owner<-", function(ssimObject, value) standardGeneric("owner<-"))
 

--- a/R/package.R
+++ b/R/package.R
@@ -8,8 +8,12 @@ NULL
 #' Packages or installed or available for this version of SyncroSim.
 #'
 #' @param session Session.
-#' @param installed Logical.  True to list installed packages and False to list available pacakges.
-#' @return A dataframe of packages
+#' @param installed Logical. `TRUE` to list installed packages and `FALSE` to list 
+#' available packages
+#' 
+#' @return 
+#' A dataframe of packages installed.
+#' 
 #' @export
 setGeneric("package", function(session, installed = T) standardGeneric("package"))
 

--- a/R/parentId.R
+++ b/R/parentId.R
@@ -5,11 +5,14 @@ NULL
 
 #' The parent scenario id of a SyncroSim Scenario.
 #'
-#' The id of the parent of a SyncroSim results scenario.
-#' NA if scenario is not a results scenario.
+#' Retrives the id of the parent of a SyncroSim results scenario.
 #'
 #' @param scenario A Scenario object.
-#' @return An integer id of the parent scenario.
+#' 
+#' @return 
+#' An integer id of the parent scenario. If the input scenario does not have a
+#' parent, the function returns `NA`.
+#' 
 #' @export
 setGeneric("parentId", function(scenario) standardGeneric("parentId"))
 

--- a/R/printCmd.R
+++ b/R/printCmd.R
@@ -5,10 +5,15 @@ NULL
 
 #' Get printCmd of a Session.
 #'
-#' Get printCmd setting of a Session object.
+#' Retrives a printCmd setting of a Session object.
 #'
-#' @param session Session or character. A Session object or path to a session. If NULL, the default session will be used.
-#' @return Logical.
+#' @param session Session or character. A Session object or path to a session. 
+#' If NULL, the default session will be used.
+#' 
+#' @return 
+#' Rteurns a logical value: `TRUE` is the session is confiured to print commands and 
+#' `FALSE` if it is not.
+#' 
 #' @export
 setGeneric("printCmd", function(session = NULL) standardGeneric("printCmd"))
 

--- a/R/project.R
+++ b/R/project.R
@@ -124,8 +124,7 @@ setMethod(f = "initialize", signature = "Project", definition = function(.Object
 
 #' Create or open a project or projects.
 #'
-#' If summary = FALSE, returns one or more \code{\link{Project}} objects representing a SyncroSim projects.
-#' If summary = TRUE, returns project summary info.
+#' Creates or retrieves a project or multiple projects from a library.
 #'
 #' @details
 #' For each element of project:
@@ -141,7 +140,11 @@ setMethod(f = "initialize", signature = "Project", definition = function(.Object
 #' @param summary Logical. If TRUE then return the project(s) in a dataframe with the projectId, name, description, owner, dateModified, readOnly. Default is TRUE if project=NULL and ssimObject is not Scenario/Project, FALSE otherwise.
 #' @param forceElements Logical. If TRUE then returns a single project as a named list; otherwise returns a single project as a Project object. Applies only when summary=FALSE.
 #' @param overwrite Logical. If TRUE an existing Project will be overwritten.
-#' @return A \code{Project} object representing a SyncroSim project, or a dataframe of project names and descriptions.
+#' 
+#' @return 
+#' A \code{Project} object representing a SyncroSim project. If summary is `TRUE`,
+#' a dataframe of project names and descriptions.
+#' 
 #' @examples
 #' \donttest{
 #' # Load a Library and create a new Project
@@ -161,6 +164,7 @@ setMethod(f = "initialize", signature = "Project", definition = function(.Object
 #' name(myProject)
 #' name(myProject) <- "New project name"
 #' }
+#' 
 #' @name project
 #' @export
 project <- function(ssimObject = NULL, project = NULL, sourceProject = NULL, summary = NULL, forceElements = F, overwrite = F) {

--- a/R/projectId.R
+++ b/R/projectId.R
@@ -5,10 +5,13 @@ NULL
 
 #' The projectId of a SyncroSim project or scenario.
 #'
-#' The projectId of a SyncroSim Project or Scenario.
+#' retrives the projectId of a SyncroSim Project or Scenario.
 #'
 #' @param ssimObject Project/Scenario.
-#' @return An integer project id.
+#' 
+#' @return 
+#' An integer project id.
+#' 
 #' @export
 setGeneric("projectId", function(ssimObject) standardGeneric("projectId"))
 #' @rdname projectId

--- a/R/readOnly.R
+++ b/R/readOnly.R
@@ -8,7 +8,11 @@ NULL
 #' Whether or not an SsimLibrary/ProjectScenario is read-only.
 #'
 #' @param ssimObject SsimLibrary/Project/Scenario.
-#' @return Logical.
+#' 
+#' @return 
+#' Returns a logical values: `TRUE` if the ssimObject is read only and `FALSE`
+#' otherwise.
+#' 
 #' @export
 setGeneric("readOnly", function(ssimObject) standardGeneric("readOnly"))
 
@@ -50,7 +54,12 @@ setMethod("readOnly", signature(ssimObject = "Scenario"), function(ssimObject) {
 #' Applies to child objects if ssimObject is an SsimLibrary or Project.
 #'
 #' @param ssimObject Scenario/Project/SsimLibrary
+#' 
 #' @param value Logical. If T the ssimObject will be read-only.
+#' 
+#' @return 
+#' The updated ssimObject.
+#' 
 #' @export
 setGeneric("readOnly<-", function(ssimObject, value) standardGeneric("readOnly<-"))
 

--- a/R/rsyncrosim.R
+++ b/R/rsyncrosim.R
@@ -10,8 +10,8 @@
 #' such as defining scenarios of inputs, running Monte Carlo simulations, and
 #' viewing charts and maps of outputs.
 #'
-#' To learn more about rsyncrosim, start with the vignette tutorial
-#' (browseVignettes("rsyncrosim")).
+#' To learn more about rsyncrosim, start with the vignette tutorial:
+#' \code{browseVignettes("rsyncrosim")}.
 #'
 #' @docType package
 #' @name rsyncrosim

--- a/R/run.R
+++ b/R/run.R
@@ -16,7 +16,12 @@ NULL
 #' @param jobs Integer. The number of jobs to run. Passed to SyncroSim where multithreading is handled.
 #' @param transformerName Character.  The name of the transformer to run.
 #' @param forceElements Logical. If TRUE then returns a single result scenario as a named list; otherwise returns a single result scenario as a Scenario object. Applies only when summary=FALSE.
-#' @return If summary=F a result Scenario object or a named list of result Scenarios. The name is the parent scenario for each result. If summary=T returns summary info for result scenarios.
+#' 
+#' @return 
+#' If \code{summary = FALSE} a result Scenario object or a named list of result Scenarios. 
+#' The name is the parent scenario for each result. If \code{summary = TRUE}, returns summary info 
+#' for result scenarios.
+#' 
 #' @export
 setGeneric("run", function(ssimObject, scenario = NULL, summary = F, jobs = 1, transformerName = NULL, forceElements = F) standardGeneric("run"))
 

--- a/R/runLog.R
+++ b/R/runLog.R
@@ -3,12 +3,15 @@
 #' @include AAAClassDefinitions.R
 NULL
 
-#' The runLog of a result Scenario
+#' The run log of a result Scenario
 #'
-#' The runLog of a result Scenario.
+#' The run log of a result Scenario.
 #'
 #' @param scenario A Scenario object.
-#' @return Character string of the run log.
+#' 
+#' @return 
+#' Rteurn a character string: the run log for a result scenario.
+#' 
 #' @export
 setGeneric("runLog", function(scenario) standardGeneric("runLog"))
 

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -36,7 +36,11 @@ NULL
 #' @param breakpoint Set to TRUE when modifying datasheets in a breakpoint function.
 #' @param import logical. Set to TRUE to import the data after saving.
 #' @param path character.  An optional output path.
-#' @return A success or failure message, or a list of these.
+#' 
+#' @return 
+#' This function invisibly returns a vector or list of logical values for each input: `TRUE` upon success (i.e.successful save)
+#' and `FALSE` upon failure.
+#' 
 #' @export
 setGeneric("saveDatasheet", function(ssimObject, data, name = NULL, fileData = NULL, append = NULL, forceElements = FALSE, force = FALSE, breakpoint = FALSE, import = TRUE, path = NULL) standardGeneric("saveDatasheet"))
 
@@ -94,7 +98,7 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), function(ssimOb
       if (length(name) != length(data)) {
         stop("Please provide a name for each element of data.")
       }
-      warning("name argument will override names(data).")
+      warning("Name argument will override names(data).")
       names(data) <- name
     } else {
       name <- names(data)
@@ -122,7 +126,7 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), function(ssimOb
           cDat[[names(cIn)[j + 1]]] <- cIn[[j + 1]]
         }
       } else {
-        stop("handle this case")
+        stop() #handle this case
       }
     }
 
@@ -139,7 +143,7 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), function(ssimOb
       sheetNames <- datasheets(x, refresh = TRUE)
       scope <- sheetNames$scope[sheetNames$name == cName]
       if (length(scope) == 0) {
-        stop("name not found in datasheetNames")
+        stop("Name not found in datasheetNames")
       }
     }
 
@@ -284,11 +288,20 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), function(ssimOb
     } else {
       out[[cName]] <- "Saved"
     }
+    
+    if (out[[cName]] == "saved"){
+      message(paste0("Datasheet <",cName, "> saved"))
+      out[[cName]] <- TRUE
+    } else {
+      message(out[[cName]])
+      out[[cName]] <- FALSE
+    }
+    
   }
-
+  
   if (!forceElements && (length(out) == 1)) {
     out <- out[[1]]
   }
   unlink(.tempfilepath(x), recursive = TRUE)
-  return(out)
+  return(invisible(out))
 })

--- a/R/scenario.R
+++ b/R/scenario.R
@@ -126,8 +126,7 @@ setMethod(
 
 #' Create or open one or more Scenarios.
 #'
-#' If summary = FALSE, returns one or more \code{\link{Scenario}} objects representing a SyncroSim scenarios.
-#' If summary = TRUE, returns scenario summary info.
+#' Create or retrievs one or more Scenarios from a library 
 #'
 #' @details
 #'
@@ -147,7 +146,12 @@ setMethod(
 #' @param results Logical. If TRUE only return result scenarios.
 #' @param forceElements Logical. If TRUE then returns a single scenario as a named list; otherwise returns a single scenario as a Scenario object. Applies only when summary=FALSE.
 #' @param overwrite Logical. If TRUE an existing Scenario will be overwritten.
-#' @return A \code{Scenario} object representing a SyncroSim scenario, a list of Scenario objects, or a dataframe of scenario names and descriptions.
+#' 
+#' @return 
+#' A \code{Scenario} object representing a SyncroSim scenario, a list of Scenario objects, or a dataframe of scenario names and descriptions.
+#' If \code{summary} = FALSE, returns one or more \code{\link{Scenario}} objects representing a SyncroSim scenarios.
+#' If \code{summary} = TRUE, returns scenario summary info.
+#' 
 #' @examples
 #' \donttest{
 #' # Create a new scenario

--- a/R/scenarioId.R
+++ b/R/scenarioId.R
@@ -5,10 +5,13 @@ NULL
 
 #' The scenarioId of a scenario.
 #'
-#' The scenarioId of a Scenario.
+#' Retrieves the scenarioId of a Scenario.
 #'
 #' @param scenario Scenario.
-#' @return Integer id.
+#' 
+#' @return 
+#' Integer id of the input scenario.
+#' 
 #' @export
 setGeneric("scenarioId", function(scenario) standardGeneric("scenarioId"))
 

--- a/R/session.R
+++ b/R/session.R
@@ -32,22 +32,29 @@ setMethod(f = "initialize", signature = "Session", definition = function(.Object
 #' Creates or returns a SyncroSim session.
 #'
 #' Methods to create or return a Syncrosim session.
+#' 
 #' @param x Character or SsimObject. An optional path to the SyncroSim installation.
 #' @param silent Logical. Applies only if x is a path or NULL. If TRUE, warnings from the console are ignored. Otherwise they are printed.
 #' @param printCmd Logical. Applies only if x is a path or NULL. If TRUE, arguments passed to the SyncroSim console are also printed. Helpful for debugging. FALSE by default.
-#' @return A SyncroSim Session object.
+#' 
+#' @return 
+#' A SyncroSim Session object.
+#' 
 #' @examples
+#' \donttest{
 #' # Create a library using a default Session and base package
 #' myLib <- ssimLibrary(name = "mylib")
 #'
 #' # Create a library using a non-default Session
-#' mySession <- session("C:/Downloads/SyncroSim")
+#' mySession <- session()
 #' myLib <- ssimLibrary(name = "mylib", session = mySession)
 #'
 #' filepath(mySession) # Lists the folder location of syncrosim session
 #' version(mySession) # Lists the version of syncrosim session
 #' package(mySession) # Dataframe of the packages installed with this version of syncrosim.
 #' basePackage(mySession) # Dataframe of the base packages installed with this version of syncrosim.
+#' }
+#' 
 #' @export
 setGeneric("session", function(x = NULL, silent = TRUE, printCmd = FALSE) standardGeneric("session"))
 
@@ -121,7 +128,10 @@ setMethod("session", signature(x = "SsimObject"), function(x, silent, printCmd) 
 #'
 #' @param ssimObject SsimObject/Project/Scenario.
 #' @param value A SyncroSim Session.
-#' @return An SyncroSim object containing a Session.
+#' 
+#' @return 
+#' An SyncroSim object containing a Session.
+#' 
 #' @export
 setGeneric("session<-", function(ssimObject, value) standardGeneric("session<-"))
 

--- a/R/silent.R
+++ b/R/silent.R
@@ -8,7 +8,10 @@ NULL
 #' Checks whether a SyncroSim Session is silent or not.
 #'
 #' @param session Session or character. A SyncroSim \code{\link{Session}} object or path to a session. If NULL, the default session will be used.
-#' @return Logical.
+#' 
+#' @return 
+#' Logical value: `TRUE` if the session is silent and `FALSE` otherwise.
+#' 
 #' @export
 setGeneric("silent", function(session) standardGeneric("silent"))
 
@@ -34,6 +37,10 @@ setMethod("silent", signature(session = "missingOrNULLOrChar"), function(session
 #'
 #' @param session Session
 #' @param value logical
+#' 
+#' @return 
+#' The updated ssimObject.
+#' 
 #' @export
 setGeneric("silent<-", function(session, value) standardGeneric("silent<-"))
 #' @rdname silent-set

--- a/R/sqlStatement.R
+++ b/R/sqlStatement.R
@@ -18,10 +18,12 @@ NULL
 #' @param aggregate character string of vector of these. Vector of variables (column names) to aggregate using aggregateFunction
 #' @param aggregateFunction character string. An SQL aggregate function (e.g. SUM, COUNT)
 #' @param where named list. A list of subset variables. Names are column names, and elements are the values to be selected from each column.
-#' @return A list of SELECT, GROUP BY and WHERE SQL statements used by datasheet() to construct an SQLite database query.
+#' 
+#' @return 
+#' A list of SELECT, GROUP BY and WHERE SQL statements used by datasheet() to construct an SQLite database query.
 #'
 #' @examples
-#'
+#' \donttest{
 #' # Query the total Amount for each combination of ScenarioID, Iteration, Timestep and StateLabelXID,
 #' # including only Timesteps 0,1 and 2, and Iterations 3 and 4.
 #' mySQL <- sqlStatement(
@@ -29,6 +31,8 @@ NULL
 #'   aggregate = c("Amount"), where = list(Timestep = c(0, 1, 2), Iteration = c(3, 4))
 #' )
 #' mySQL
+#' }
+#' 
 #' @export
 sqlStatement <- function(groupBy = NULL, aggregate = NULL, aggregateFunction = "SUM", where = NULL) {
   if (is.null(groupBy)) {

--- a/R/ssimEnvironment.R
+++ b/R/ssimEnvironment.R
@@ -5,7 +5,9 @@
 #'
 #' Retrieves SyncroSim specific environment variables.
 #'
-#' @return A data.frame of SyncroSim specific environment variables.
+#' @return 
+#' A data.frame of SyncroSim specific environment variables.
+#' 
 #' @export
 #' @rdname ssimEnvironment
 ssimEnvironment <- function() {

--- a/R/ssimLibrary.R
+++ b/R/ssimLibrary.R
@@ -190,6 +190,7 @@ setMethod(".ssimLibrary", signature(name = "SsimObject"), function(name, package
 #'   \item {If name is a string: }{If string is not a valid path treat as filename in working directory. If no file suffix provided in string then add .ssim. Attempts to open a library of that name. If library does not exist creates a library of type package in the current working directory.}
 #'   \item {If given a name and a package: }{Create/open a library called <name>.ssim. Returns an error if the library already exists but is a different type of package.}
 #' }
+#' 
 #' @param name Character string, Project/Scenario/SsimLibrary. The path to a library or SsimObject.
 #' @param summary logical. Default T
 #' @param package Character. The package type. The default is "stsim".
@@ -197,7 +198,10 @@ setMethod(".ssimLibrary", signature(name = "SsimObject"), function(name, package
 #' @param addon Character or character vector. One or more addons. See addon() for options.
 #' @param forceUpdate Logical. If FALSE (default) user will be prompted to approve any required updates. If TRUE, required updates will be applied silently.
 #' @param overwrite Logical. If TRUE an existing Library will be overwritten.
-#' @return An \code{SsimLibrary} object.
+#' 
+#' @return 
+#' An \code{SsimLibrary} object.
+#' 
 #' @examples
 #' \donttest{
 #' # Create a library using the default session
@@ -207,13 +211,14 @@ setMethod(".ssimLibrary", signature(name = "SsimObject"), function(name, package
 #' myLibrary <- ssimLibrary(name = "myLib")
 #'
 #' # Create library using a specific session
-#' mySession <- session("C:/Downloads/SyncroSim")
+#' mySession <- session()
 #' myLibrary <- ssimLibrary(name = "myLib", session = mySession)
 #'
 #' session(myLibrary)
 #' filepath(myLibrary)
 #' info(myLibrary)
 #' }
+#' 
 #' @export
 setGeneric("ssimLibrary", function(name = NULL, summary = NULL, package = NULL, session = NULL, addon = NULL, forceUpdate = F, overwrite = F) standardGeneric("ssimLibrary"))
 
@@ -276,6 +281,7 @@ setMethod("info", signature(ssimLibrary = "SsimLibrary"), function(ssimLibrary) 
 # @param force Logical. If FALSE (default) prompt to confirm that the library should be deleted. This is irreversable.
 # @return "saved" or failure message.
 # @export
+
 setGeneric("deleteLibrary", function(ssimLibrary, force = F) standardGeneric("deleteLibrary"))
 
 setMethod("deleteLibrary", signature(ssimLibrary = "SsimLibrary"), function(ssimLibrary, force) {

--- a/R/ssimUpdate.R
+++ b/R/ssimUpdate.R
@@ -8,7 +8,11 @@ NULL
 #' Apply updates to a SyncroSim Library,or a Project or Scenario associated with a Library.
 #'
 #' @param ssimObject  SsimLibrary/Project/Scenario
-#' @return Character "saved" in case of success or error message.
+#' 
+#' @return 
+#' This function invisibly returns `TRUE` upon success (i.e.successful 
+#' update) and `FALSE` upon failure.
+#' 
 #' @export
 setGeneric("ssimUpdate", function(ssimObject) standardGeneric("ssimUpdate"))
 
@@ -19,6 +23,16 @@ setMethod("ssimUpdate", signature(ssimObject = "character"), function(ssimObject
 
 #' @rdname ssimUpdate
 setMethod("ssimUpdate", signature(ssimObject = "SsimObject"), function(ssimObject) {
+  success <- FALSE
   tt <- command(list(update = NULL, lib = .filepath(ssimObject)), .session(ssimObject))
-  return(tt[1])
+  if (!is.na(tt[1])){ 
+    if (tt == "saved"){
+      message("Library successfully updated")
+      success <- TRUE
+    } else{
+      message(tt)
+    }
+  }
+  return(invisible(success))
 })
+  

--- a/R/updatePackage.R
+++ b/R/updatePackage.R
@@ -10,6 +10,11 @@ NULL
 #' @param name Character string.  The name of the package to update.  If NULL, all packages will be updated.
 #' @param session Session.
 #' @param listonly Logical.  If TRUE, available updates are listed only.
+#' 
+#' @return 
+#' This function invisibly returns `TRUE` upon success (i.e.successful update)
+#' and `FALSE` upon failure.
+#' 
 #' @export
 setGeneric("updatePackage", function(name = NULL, session = NULL, listonly = F) standardGeneric("updatePackage"))
 
@@ -26,32 +31,46 @@ setMethod("updatePackage", signature(session = "missingOrNULL"), function(name, 
 
 #' @rdname updatePackage
 setMethod("updatePackage", signature(session = "Session"), function(name, session, listonly) {
+  success <- FALSE
+  
   if (listonly) {
-    tt <- command(args = "--updates", session, program = "SyncroSim.PackageManager.exe")
-    return(cat(tt, sep = "\n"))
+    tt <- command(args = "--updates", session, program = "SyncroSim.PackageManager.exe", )
+    if (is.na(tt[1])){
+      message("Could not connect to the package server.") # tt is NA du to connection error
+    }
+    return(invisible(success))
   }
-
+  
   tt <- NULL
-
+  
   if (is.null(name)) {
     answer <- readline(prompt = "Update all packages? (y/n)")
-
+    
     if (answer == "y") {
       tt <- command(args = "--updateall --force", session, program = "SyncroSim.PackageManager.exe")
+    } else {
+      message("Update process skipped")
+      return(invisible(success))
     }
   } else {
     installed <- package(session)
-
+    
     if (!is.element(name, installed$name)) {
-      tt <- paste(name, ": The package is not installed.")
+      message(paste(name, ": The package is not installed."))
+      return(invisible(success))
     } else {
       tt <- command(args = list(updatepkg = name), session, program = "SyncroSim.PackageManager.exe")
+      if (!is.na(tt[1])){
+        if (tt == "saved"){
+          success <- TRUE
+        } else {
+          message(tt)
+        }
+      } else{
+        message("Could not connect to the package server.") # tt is NA du to connection error
+      }
     }
   }
-
-  if (grepl("The remote name could not be resolved", tt[1])) {
-    tt <- "Could not connect to the package server."
-  }
-
-  return(tt)
+  
+  return(invisible(success))
 })

--- a/man/addPackage.Rd
+++ b/man/addPackage.Rd
@@ -16,10 +16,15 @@ addPackage(name, session = NULL)
 \S4method{addPackage}{ANY,Session}(name, session = NULL)
 }
 \arguments{
-\item{name}{Character string.  The name of the package to install from the online package server.}
+\item{name}{Character string.  The name of the package to install.}
 
 \item{session}{Session.}
 }
+\value{
+This function will inivisibly return `TRUE` upon success (i.e.successful 
+install) and `FALSE` upon failure.
+}
 \description{
-Adds a package to SyncroSim.
+Adds a package to SyncroSim. This functions will query the syncrosim 
+package server for the package name provided as input.
 }

--- a/man/addPackageFile.Rd
+++ b/man/addPackageFile.Rd
@@ -20,6 +20,10 @@ addPackageFile(filename, session = NULL)
 
 \item{session}{Session.}
 }
+\value{
+This function invisibly returns `TRUE` upon success (i.e.successful 
+install) and `FALSE` upon failure.
+}
 \description{
-Adds a package to SyncroSim
+Adds a package to SyncroSim from a package file.
 }

--- a/man/addon.Rd
+++ b/man/addon.Rd
@@ -31,4 +31,5 @@ The addon(s) of an SsimLibrary or Session.
 \donttest{
 addon(ssimLibrary(name = "mylib"))
 }
+
 }

--- a/man/backup.Rd
+++ b/man/backup.Rd
@@ -15,6 +15,10 @@ backup(ssimObject)
 \arguments{
 \item{ssimObject}{SsimLibrary/Project/Scenario.}
 }
+\value{
+This function inivisibly returns `TRUE` upon success (i.e.successful 
+backup) and `FALSE` upon failure.
+}
 \description{
 Backup an SsimLibrary.
 }

--- a/man/breakpoint.Rd
+++ b/man/breakpoint.Rd
@@ -12,6 +12,9 @@ breakpoint(x)
 \arguments{
 \item{x}{A SyncroSim Scenario}
 }
+\value{
+Does not return anything, used for printing purposes.
+}
 \description{
 Lists the breakpoints for a Scenario.
 }

--- a/man/command.Rd
+++ b/man/command.Rd
@@ -16,7 +16,7 @@ command(args, session = NULL, program = "SyncroSim.Console.exe", wait = TRUE)
 \item{wait}{Logical. If TRUE (default) R will wait for the command to finish before proceeding. Note that silent(session) is ignored if wait=FALSE.}
 }
 \value{
-Output from the SyncroSim program.
+A chracter string, output from the SyncroSim program.
 }
 \description{
 Issues a command to the SyncroSim console and returns the output.
@@ -30,6 +30,7 @@ Example args, and the resulting character string passed to the SyncroSim console
 }
 }
 \examples{
+\donttest{
 # Use a default session to create a new library in the current working directory.
 args <- list(create = NULL, library = NULL, name = paste0(getwd(), "/temp.ssim"), package = "stsim")
 output <- command(args, session = session(printCmd = TRUE))
@@ -39,4 +40,5 @@ output
 command(c("create", "help"))
 command("--create --help")
 command(list(create = NULL, help = NULL))
+}
 }

--- a/man/datasheet.Rd
+++ b/man/datasheet.Rd
@@ -95,7 +95,7 @@ datasheet(
 If summary=TRUE returns a dataframe of datasheet names and other info, otherwise returns a dataframe or list of these.
 }
 \description{
-Gets SyncroSim datasheet.
+Retrieves a SyncroSim datasheet.
 }
 \details{
 If summary=TRUE or summary=NULL and name=NULL a dataframe describing the datasheets is returned:

--- a/man/datasheetRaster.Rd
+++ b/man/datasheetRaster.Rd
@@ -98,4 +98,5 @@ datasheetRaster(myResult,
   subset = expression(grepl("Ts0001", Filename, fixed = T))
 )
 }
+
 }

--- a/man/dateModified.Rd
+++ b/man/dateModified.Rd
@@ -21,6 +21,10 @@ dateModified(ssimObject)
 \arguments{
 \item{ssimObject}{SsimLibrary/Project/Scenario.}
 }
+\value{
+A character string of the date and time of the most recent modification 
+to the ssimObject provided as input.
+}
 \description{
 The most recent modification date of an SsimLibrary/Project/Scenario
 }

--- a/man/delete.Rd
+++ b/man/delete.Rd
@@ -42,7 +42,8 @@ delete(
 \item{force}{logical. If FALSE (default), user will be prompted to approve removal of each item.}
 }
 \value{
-A list of "saved" or failure messages for each item.
+This function returns invisibly a list of boolean values corresponding to each of the
+input: `TRUE` upon success (i.e.successful deletion) and `FALSE` upon failure.
 }
 \description{
 Deletes one or more items. Note this is irreversible
@@ -55,4 +56,5 @@ project(myLibrary)
 delete(myLibrary, project = "a project")
 project(myLibrary)
 }
+
 }

--- a/man/deletePackage.Rd
+++ b/man/deletePackage.Rd
@@ -7,13 +7,13 @@
 \alias{deletePackage,ANY,Session-method}
 \title{Deletes a package}
 \usage{
-deletePackage(name, session = NULL, force = F)
+deletePackage(name, session = NULL, force = FALSE)
 
-\S4method{deletePackage}{ANY,character}(name, session = NULL, force = F)
+\S4method{deletePackage}{ANY,character}(name, session = NULL, force = FALSE)
 
-\S4method{deletePackage}{ANY,missingOrNULL}(name, session = NULL, force = F)
+\S4method{deletePackage}{ANY,missingOrNULL}(name, session = NULL, force = FALSE)
 
-\S4method{deletePackage}{ANY,Session}(name, session = NULL, force = F)
+\S4method{deletePackage}{ANY,Session}(name, session = NULL, force = FALSE)
 }
 \arguments{
 \item{name}{Character. The name of the package to delete.}
@@ -23,8 +23,9 @@ deletePackage(name, session = NULL, force = F)
 \item{force}{logical. If T, delete without requiring confirmation from user.}
 }
 \value{
-"saved" or error message.
+This function invisibly returns `TRUE` upon success (i.e.successful 
+deletion) and `FALSE` upon failure.
 }
 \description{
-Deletes a package.
+Deletes a package from your syncrosim instalation.
 }

--- a/man/dependency.Rd
+++ b/man/dependency.Rd
@@ -22,7 +22,10 @@ dependency(scenario, dependency = NULL, remove = F, force = F)
 \item{force}{logical. If F (default) prompt before removing dependencies.}
 }
 \value{
-If dependency!=NULL, character string (saved or error message) or list of these. Otherwise, a dataframe of existing dependencies, or list of these.
+If dependency is NULL, a dataframe of existing dependencies, or list of these if multiple
+inputs are provided.
+If dependency is not NULL, the function invisibly returns a list bearing the names of the dependencies inputed
+and carrying a boolean `TRUE` upon success (i.e.successful addition or deletion) and `FALSE` upon failure.
 }
 \description{
 Set or remove Scenario dependency(s), or get existing dependencies.

--- a/man/description-set.Rd
+++ b/man/description-set.Rd
@@ -17,6 +17,9 @@ description(ssimObject) <- value
 
 \item{value}{The new description.}
 }
+\value{
+The object with updated description.
+}
 \description{
 Set the description of an SsimLibrary/ProjectScenario.
 }

--- a/man/description.Rd
+++ b/man/description.Rd
@@ -15,6 +15,9 @@ description(ssimObject)
 \arguments{
 \item{ssimObject}{SsimLibrary/Project/Scenario.}
 }
+\value{
+A character string describing the ssimObject.
+}
 \description{
 The description of an SsimLibrary/ProjectScenario.
 }

--- a/man/disableAddon.Rd
+++ b/man/disableAddon.Rd
@@ -18,17 +18,19 @@ disableAddon(ssimLibrary, name)
 \item{name}{Character string or vector of addon names}
 }
 \value{
-Character "saved" in case of success or error message.
+This function invisibly returns `TRUE` upon success (i.e.successful deactivation of the addon 
+and `FALSE` upon failure.
 }
 \description{
 Disable addon or addons of an SsimLibrary, or Project/Scenario with an associated SsimLibrary.
 }
 \examples{
+\donttest{
 myLibrary <- ssimLibrary("mylib")
 enableAddon(myLibrary, c("stsimecodep"))
 addon(myLibrary)
-\donttest{
 disableAddon(myLibrary, c("stsimecodep"))
-}
 addon(myLibrary)
+}
+
 }

--- a/man/enableAddon.Rd
+++ b/man/enableAddon.Rd
@@ -18,7 +18,8 @@ enableAddon(ssimLibrary, name)
 \item{name}{Character string or vector of addon names}
 }
 \value{
-Character "saved" in case of success or error message.
+This function invisibly returns `TRUE` upon success (i.e.successful activation of the addon 
+and `FALSE` upon failure.
 }
 \description{
 Enable addon or addons of an SsimLibrary.
@@ -31,4 +32,5 @@ addon(myLibrary)
 disableAddon(myLibrary, c("stsim-ecological-departure"))
 addon(myLibrary)
 }
+
 }

--- a/man/filepath.Rd
+++ b/man/filepath.Rd
@@ -18,6 +18,9 @@ filepath(ssimObject)
 \arguments{
 \item{ssimObject}{An object containing a filepath.}
 }
+\value{
+A character string: the path to a SyncroSim object on disk.
+}
 \description{
 The path to a SyncroSim Session, SSimLibarary, Project or Scenario on disk.
 }

--- a/man/mergeDependencies-set.Rd
+++ b/man/mergeDependencies-set.Rd
@@ -17,6 +17,9 @@ mergeDependencies(ssimObject) <- value
 
 \item{value}{Logical. If T the Scenario will be set to merge dependencies at runtime.}
 }
+\value{
+The updated ssimObject.
+}
 \description{
-Whether or not a Scenario is configured to merge dependencies at run time.
+Sets whether or not a Scenario is configured to merge dependencies at run time.
 }

--- a/man/mergeDependencies.Rd
+++ b/man/mergeDependencies.Rd
@@ -16,8 +16,9 @@ mergeDependencies(ssimObject)
 \item{ssimObject}{Scenario}
 }
 \value{
-logical.
+Returns a logical: `TRUE` is the scenario is configured to merge dependencies at run time, 
+and `FALSE` otherwise.
 }
 \description{
-Whether or not a Scenario is configured to merge dependencies at run time.
+Retrieves whether or not a Scenario is configured to merge dependencies at run time.
 }

--- a/man/module.Rd
+++ b/man/module.Rd
@@ -19,7 +19,7 @@ module(session)
 \item{session}{Session.}
 }
 \value{
-A dataframe of modules
+A dataframe of modules.
 }
 \description{
 Deprecated.  See: \code{\link{package}}

--- a/man/name-set.Rd
+++ b/man/name-set.Rd
@@ -21,7 +21,7 @@ name(ssimObject) <- value
 \arguments{
 \item{ssimObject}{Scenario/Project/SsimLibrary}
 
-\item{value}{The new name.}
+\item{value}{The updated ssimObject.}
 }
 \description{
 Set the name of a SyncroSim Project, Scenario or Library

--- a/man/name.Rd
+++ b/man/name.Rd
@@ -22,8 +22,8 @@ name(ssimObject)
 \item{ssimObject}{SsimLibrary, Project, or Scenario.}
 }
 \value{
-Character string
+Character string: the name of the ssimObject.
 }
 \description{
-The name of an SsimLibrary, Project or Scenario.
+Retrieves the name of an SsimLibrary, Project or Scenario.
 }

--- a/man/owner-set.Rd
+++ b/man/owner-set.Rd
@@ -17,6 +17,9 @@ owner(ssimObject) <- value
 
 \item{value}{The new owner.}
 }
+\value{
+The updated ssimObject.
+}
 \description{
 Set the owner of an SsimLibrary/Project/Scenario.
 }

--- a/man/owner.Rd
+++ b/man/owner.Rd
@@ -21,6 +21,9 @@ owner(ssimObject)
 \arguments{
 \item{ssimObject}{SsimLibrary/Project/Scenario.}
 }
+\value{
+A character string: the owner of the ssimObject.
+}
 \description{
-The owner of an SsimLibrary/ProjectScenario
+Retrieves the owner of an SsimLibrary/ProjectScenario
 }

--- a/man/package.Rd
+++ b/man/package.Rd
@@ -18,10 +18,11 @@ package(session, installed = T)
 \arguments{
 \item{session}{Session.}
 
-\item{installed}{Logical.  True to list installed packages and False to list available pacakges.}
+\item{installed}{Logical. `TRUE` to list installed packages and `FALSE` to list 
+available packages}
 }
 \value{
-A dataframe of packages
+A dataframe of packages installed.
 }
 \description{
 Packages or installed or available for this version of SyncroSim.

--- a/man/parentId.Rd
+++ b/man/parentId.Rd
@@ -16,9 +16,9 @@ parentId(scenario)
 \item{scenario}{A Scenario object.}
 }
 \value{
-An integer id of the parent scenario.
+An integer id of the parent scenario. If the input scenario does not have a
+parent, the function returns `NA`.
 }
 \description{
-The id of the parent of a SyncroSim results scenario.
-NA if scenario is not a results scenario.
+Retrives the id of the parent of a SyncroSim results scenario.
 }

--- a/man/printCmd.Rd
+++ b/man/printCmd.Rd
@@ -13,11 +13,13 @@ printCmd(session = NULL)
 \S4method{printCmd}{missingOrNULLOrChar}(session = NULL)
 }
 \arguments{
-\item{session}{Session or character. A Session object or path to a session. If NULL, the default session will be used.}
+\item{session}{Session or character. A Session object or path to a session. 
+If NULL, the default session will be used.}
 }
 \value{
-Logical.
+Rteurns a logical value: `TRUE` is the session is confiured to print commands and 
+`FALSE` if it is not.
 }
 \description{
-Get printCmd setting of a Session object.
+Retrives a printCmd setting of a Session object.
 }

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -27,11 +27,11 @@ project(
 \item{overwrite}{Logical. If TRUE an existing Project will be overwritten.}
 }
 \value{
-A \code{Project} object representing a SyncroSim project, or a dataframe of project names and descriptions.
+A \code{Project} object representing a SyncroSim project. If summary is `TRUE`,
+a dataframe of project names and descriptions.
 }
 \description{
-If summary = FALSE, returns one or more \code{\link{Project}} objects representing a SyncroSim projects.
-If summary = TRUE, returns project summary info.
+Creates or retrieves a project or multiple projects from a library.
 }
 \details{
 For each element of project:
@@ -60,4 +60,5 @@ myProject <- project(myLibrary, project = "My new project name")
 name(myProject)
 name(myProject) <- "New project name"
 }
+
 }

--- a/man/projectId.Rd
+++ b/man/projectId.Rd
@@ -22,5 +22,5 @@ projectId(ssimObject)
 An integer project id.
 }
 \description{
-The projectId of a SyncroSim Project or Scenario.
+retrives the projectId of a SyncroSim Project or Scenario.
 }

--- a/man/readOnly-set.Rd
+++ b/man/readOnly-set.Rd
@@ -17,6 +17,9 @@ readOnly(ssimObject) <- value
 
 \item{value}{Logical. If T the ssimObject will be read-only.}
 }
+\value{
+The updated ssimObject.
+}
 \description{
 Set the read-only status of an SsimLibrary/Project/Scenario.
 Applies to child objects if ssimObject is an SsimLibrary or Project.

--- a/man/readOnly.Rd
+++ b/man/readOnly.Rd
@@ -22,7 +22,8 @@ readOnly(ssimObject)
 \item{ssimObject}{SsimLibrary/Project/Scenario.}
 }
 \value{
-Logical.
+Returns a logical values: `TRUE` if the ssimObject is read only and `FALSE`
+otherwise.
 }
 \description{
 Whether or not an SsimLibrary/ProjectScenario is read-only.

--- a/man/rsyncrosim.Rd
+++ b/man/rsyncrosim.Rd
@@ -13,6 +13,6 @@ such as defining scenarios of inputs, running Monte Carlo simulations, and
 viewing charts and maps of outputs.
 }
 \details{
-To learn more about rsyncrosim, start with the vignette tutorial
-(browseVignettes("rsyncrosim")).
+To learn more about rsyncrosim, start with the vignette tutorial:
+\code{browseVignettes("rsyncrosim")}.
 }

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -60,7 +60,9 @@ run(
 \item{forceElements}{Logical. If TRUE then returns a single result scenario as a named list; otherwise returns a single result scenario as a Scenario object. Applies only when summary=FALSE.}
 }
 \value{
-If summary=F a result Scenario object or a named list of result Scenarios. The name is the parent scenario for each result. If summary=T returns summary info for result scenarios.
+If \code{summary = FALSE} a result Scenario object or a named list of result Scenarios. 
+The name is the parent scenario for each result. If \code{summary = TRUE}, returns summary info 
+for result scenarios.
 }
 \description{
 Run one or more SyncroSim scenarios.

--- a/man/runLog.Rd
+++ b/man/runLog.Rd
@@ -4,7 +4,7 @@
 \alias{runLog}
 \alias{runLog,character-method}
 \alias{runLog,Scenario-method}
-\title{The runLog of a result Scenario}
+\title{The run log of a result Scenario}
 \usage{
 runLog(scenario)
 
@@ -16,8 +16,8 @@ runLog(scenario)
 \item{scenario}{A Scenario object.}
 }
 \value{
-Character string of the run log.
+Rteurn a character string: the run log for a result scenario.
 }
 \description{
-The runLog of a result Scenario.
+The run log of a result Scenario.
 }

--- a/man/saveDatasheet.Rd
+++ b/man/saveDatasheet.Rd
@@ -67,7 +67,8 @@ saveDatasheet(
 \item{path}{character.  An optional output path.}
 }
 \value{
-A success or failure message, or a list of these.
+This function invisibly returns a vector or list of logical values for each input: `TRUE` upon success (i.e.successful save)
+and `FALSE` upon failure.
 }
 \description{
 Saves datasheets to a SsimLibrary/Project/Scenario.

--- a/man/scenario.Rd
+++ b/man/scenario.Rd
@@ -31,10 +31,11 @@ scenario(
 }
 \value{
 A \code{Scenario} object representing a SyncroSim scenario, a list of Scenario objects, or a dataframe of scenario names and descriptions.
+If \code{summary} = FALSE, returns one or more \code{\link{Scenario}} objects representing a SyncroSim scenarios.
+If \code{summary} = TRUE, returns scenario summary info.
 }
 \description{
-If summary = FALSE, returns one or more \code{\link{Scenario}} objects representing a SyncroSim scenarios.
-If summary = TRUE, returns scenario summary info.
+Create or retrievs one or more Scenarios from a library
 }
 \details{
 For each element of scenario:

--- a/man/scenarioId.Rd
+++ b/man/scenarioId.Rd
@@ -16,8 +16,8 @@ scenarioId(scenario)
 \item{scenario}{Scenario.}
 }
 \value{
-Integer id.
+Integer id of the input scenario.
 }
 \description{
-The scenarioId of a Scenario.
+Retrieves the scenarioId of a Scenario.
 }

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -26,15 +26,18 @@ A SyncroSim Session object.
 Methods to create or return a Syncrosim session.
 }
 \examples{
+\donttest{
 # Create a library using a default Session and base package
 myLib <- ssimLibrary(name = "mylib")
 
 # Create a library using a non-default Session
-mySession <- session("C:/Downloads/SyncroSim")
+mySession <- session()
 myLib <- ssimLibrary(name = "mylib", session = mySession)
 
 filepath(mySession) # Lists the folder location of syncrosim session
 version(mySession) # Lists the version of syncrosim session
 package(mySession) # Dataframe of the packages installed with this version of syncrosim.
 basePackage(mySession) # Dataframe of the base packages installed with this version of syncrosim.
+}
+
 }

--- a/man/silent-set.Rd
+++ b/man/silent-set.Rd
@@ -17,6 +17,9 @@ silent(session) <- value
 
 \item{value}{logical}
 }
+\value{
+The updated ssimObject.
+}
 \description{
 Set silent property of a sessio to TRUE or FALSE
 }

--- a/man/silent.Rd
+++ b/man/silent.Rd
@@ -16,7 +16,7 @@ silent(session)
 \item{session}{Session or character. A SyncroSim \code{\link{Session}} object or path to a session. If NULL, the default session will be used.}
 }
 \value{
-Logical.
+Logical value: `TRUE` if the session is silent and `FALSE` otherwise.
 }
 \description{
 Checks whether a SyncroSim Session is silent or not.

--- a/man/sqlStatement.Rd
+++ b/man/sqlStatement.Rd
@@ -34,7 +34,7 @@ Note that it is not possible to construct a complete SQL query at this stage,
 because the datasheet() function may add ScenarioID and/or ProjectID to the query.
 }
 \examples{
-
+\donttest{
 # Query the total Amount for each combination of ScenarioID, Iteration, Timestep and StateLabelXID,
 # including only Timesteps 0,1 and 2, and Iterations 3 and 4.
 mySQL <- sqlStatement(
@@ -42,4 +42,6 @@ mySQL <- sqlStatement(
   aggregate = c("Amount"), where = list(Timestep = c(0, 1, 2), Iteration = c(3, 4))
 )
 mySQL
+}
+
 }

--- a/man/ssimLibrary.Rd
+++ b/man/ssimLibrary.Rd
@@ -76,11 +76,12 @@ myLibrary <- ssimLibrary(name = "myLib")
 myLibrary <- ssimLibrary(name = "myLib")
 
 # Create library using a specific session
-mySession <- session("C:/Downloads/SyncroSim")
+mySession <- session()
 myLibrary <- ssimLibrary(name = "myLib", session = mySession)
 
 session(myLibrary)
 filepath(myLibrary)
 info(myLibrary)
 }
+
 }

--- a/man/ssimUpdate.Rd
+++ b/man/ssimUpdate.Rd
@@ -16,7 +16,8 @@ ssimUpdate(ssimObject)
 \item{ssimObject}{SsimLibrary/Project/Scenario}
 }
 \value{
-Character "saved" in case of success or error message.
+This function invisibly returns `TRUE` upon success (i.e.successful 
+update) and `FALSE` upon failure.
 }
 \description{
 Apply updates to a SyncroSim Library,or a Project or Scenario associated with a Library.

--- a/man/updatePackage.Rd
+++ b/man/updatePackage.Rd
@@ -22,6 +22,10 @@ updatePackage(name = NULL, session = NULL, listonly = F)
 
 \item{listonly}{Logical.  If TRUE, available updates are listed only.}
 }
+\value{
+This function invisibly returns `TRUE` upon success (i.e.successful update)
+and `FALSE` upon failure.
+}
 \description{
 Updates a SyncroSim package.
 }

--- a/tests/testthat/test-unit.R
+++ b/tests/testthat/test-unit.R
@@ -135,14 +135,14 @@ test_that("Tests of projects and scenarios - assumes SyncroSim is installed", {
   myScn <- scenario(myProject, scenario = "one", overwrite = T) # Overwrites existing scenario, assigns new id.
   expect_equal(scenario(myLib)$scenarioId, c(1, 3))
   myScn <- scenario(myProject, scenario = "two", overwrite = T, sourceScenario = 1) # Can copy scenarios between projects.
-  expect_equal(projectId(myScn), 10)
+  expect_equal(projectId(myScn), 11)
   myScn <- scenario(myProject, scenario = "other", overwrite = T, sourceScenario = myOtherScn) # Can copy scenarios between libraries if sourceScenario is a scenario object.
   expect_equal(scenarioId(myScn), 5)
 
   myOtherProject <- project(myOtherLib, project = "copy", sourceProject = myProject) # Can copy projects among libraries provided that sourceProject is a Project object.
 
   # TODO This fails for an unknown reason => BUG SUBMITED
-  myOtherProject <- project(myLib, project = "copy", sourceProject = 10) # Copy a project within the same library.
+  myOtherProject <- project(myLib, project = "copy", sourceProject = 11) # Copy a project within the same library.
   expect_equal(projectId(myOtherProject), 19)
   expect_warning(project(myLib, project = "temp", sourceProject = "temp2"), "Project  (1) already exists, so sourceProject argument was ignored.", fixed = T) # Warns that sourceProject is ignored because "temp" already exists.
   myOtherProject <- project(myLib, project = "copy2", sourceProject = "temp2") # Copy a project by name

--- a/tests/testthat/test-unit.R
+++ b/tests/testthat/test-unit.R
@@ -35,7 +35,7 @@ test_that("Tests of command  - assumes SyncroSim is installed", {
   expect_equal(command(list(create = NULL, help = NULL), mySsim)[1], "Creates an item")
 
   ret <- delete(paste0(getwd(), "/temp.ssim"), force = T)
-  args <- list(create = NULL, library = NULL, name = paste0(getwd(), "/temp.ssim"), package = "hello:model-transformer")
+  args <- list(create = NULL, library = NULL, name = paste0(getwd(), "/temp.ssim"), package = "nonexistentpackage")
   output <- command(args, mySsim)
   expect_equal(output[1], "The specified package is not installed.")
 })
@@ -45,7 +45,7 @@ test_that("Tests of Library - assumes SyncroSim is installed", {
   myLibrary <- ssimLibrary(name = "temp", session = mySsim) # create new library using default model
   expect_equal(file.exists(filepath(myLibrary)), TRUE)
   expect_equal(as.character(basePackage(myLibrary)$name), "stsim")
-  expect_equal(delete(myLibrary, force = T), "saved")
+  expect_equal(delete(myLibrary, force = T), TRUE)
   expect_equal(file.exists(filepath(myLibrary)), FALSE)
 
   myLibrary <- ssimLibrary(name = "SSimLibrary", session = mySsim)
@@ -57,7 +57,7 @@ test_that("Tests of Library - assumes SyncroSim is installed", {
   allAdds <- addon(myLibrary)
   expect_equal(names(allAdds), c("name", "description", "enabled", "currentVersion", "minimumVersion"))
   expect_equal(names(addon(mySsim)), c("name", "description", "version", "extends"))
-  expect_equal(delete(myLibrary, force = T), "saved")
+  expect_equal(delete(myLibrary, force = T), TRUE)
 
   allAdds <- subset(allAdds, name != "stsim-cbm") # Requires stsim-stockflow to be added first
 
@@ -65,23 +65,23 @@ test_that("Tests of Library - assumes SyncroSim is installed", {
     cAdd <- allAdds$name[1]
     myLibrary <- ssimLibrary(name = "NewLibrary", addon = c(cAdd), session = mySsim)
     expect_equal(subset(addon(myLibrary), enabled)$name, cAdd)
-    expect_equal(disableAddon(myLibrary, cAdd)[[cAdd]], "saved")
+    expect_equal(disableAddon(myLibrary, cAdd)[[cAdd]], TRUE)
     expect_equal(nrow(subset(addon(myLibrary), enabled)), 0)
-    expect_equal(enableAddon(myLibrary, cAdd)[[cAdd]], "saved")
+    expect_equal(enableAddon(myLibrary, cAdd)[[cAdd]], TRUE)
     expect_equal(subset(addon(myLibrary), enabled)$name, cAdd)
   }
 
   # Get/set the various properties of the library
   expect_is("session<-"(myLibrary, mySsim), "SsimLibrary")
 
-  # Chnaged from "The library has no unapplied updates." to NA because testhat cannot detect the command message
-  expect(is.na(ssimUpdate(myLibrary)), "ssimUpdate test failed, value returned is not NA")
+  # Changed from NA to FALSE to match updated behaviors
+  expect_equal(ssimUpdate(myLibrary), FALSE)
   expect_equal(names(ssimLibrary(myLibrary, session = mySsim)), c("property", "value"))
   expect_equal(class(ssimLibrary(myLibrary, summary = F, mySsim))[1], "SsimLibrary")
 
   name(myLibrary) <- "Fred"
   expect_equal(name(myLibrary), "Fred")
-  expect_equal(backup(myLibrary), "Backup complete.")
+  expect_equal(backup(myLibrary), TRUE)
   expect_equal(dir.exists(paste0(filepath(myLibrary), ".backup")), T)
 
   description(myLibrary) <- "A new description.\nTry a linebreak." # NOTE: \n adds a linebreak to the description


### PR DESCRIPTION
This PR make a change to the behavior of a few functions: all functions that previously returned a string the "saved" coming from the command line now **invisibly** (see `?invisible`) return a boolean based on whether or not the function succeeded. It also introduces new messages for each operation. for instance deleting a `ssimobject` or creating a new dependency sends a simple console message. 

These changes were decided by @colindaniel based on CRAN review comments which commented that returned string like this all the time for no "R-like".