### PR TITLE
Refactor save datasheet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsyncrosim
 Type: Package
 Title: The R Interface to 'SyncroSim'
-Version: 2.1.2
+Version: 2.1.3
 Authors@R: c(
     person("Colin", "Daniel", email = "colin.daniel@apexrms.com",
            role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,22 +1,21 @@
-# rsyncrosim 2.1.2
+# rsyncrosim 2.1.3
 
-## Breaking changes
+## Breaking changes:
 
-* Incremented compatible SyncroSim version to 3.1
+* Removed the following arguments from `saveDatasheet()`:
+  * `fileData`
+  * `forceElements`
+  * `breakpoint`
+  * `import`
+  * `path`
 
 ## Bug fixes:
 
-* Fix `filterValue` and `filterColumn` arguments in `datasheet()` and `datasheetSpatRaster()` 
-* Fix issues with factor lookups not working in `datasheet()` function
-* Fix bug in `installPackage()` and `uninstallPackage()` preventing package install when no packages installed yet
+* Fix error when dataframe columns of type double contain both NAs and values and you try to use `saveDatasheet()`
 
 ## New features:
 
-* Add `software` argument to `installConda()` for installing miniforge
-* Add authentication functions `signIn()`, `signOut()`, and `viewProfile()`
+## Minor improvements and fixes:
 
+* Refactored `saveDatasheet`
 
-## Minor improvements and fixes
-
-* Fix issue when loading a library where rsyncrosim always throws a warning that the package has not been installed properly if the package was built against SyncroSim 3.0
-* Documentation updates and fixes

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -198,6 +198,8 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
   write.csv(data, file = tempFile, row.names = FALSE, quote = TRUE)
 
   # If not running in SyncroSim env then import changes to ssim database
+  out <- TRUE
+  
   if (import) {
     
     args <- list(import = NULL, lib = .filepath(ssimObject), sheet = name, file = tempFile)
@@ -220,20 +222,11 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
     
     if (tt[[1]] == "saved") {
       unlink(tempFile)
+      message(paste0("Datasheet <",name, "> saved"))
+    } else {
+      out <- FALSE
+      message(tt[[1]])
     }
-    out <- tt
-    
-  } else {
-    
-    out <- "Saved"
-  }
-  
-  if (out == "saved"){
-    message(paste0("Datasheet <",name, "> saved"))
-    out <- TRUE
-  } else {
-    message(out)
-    out <- FALSE
   }
   
   # Clean up temporary files

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -83,8 +83,7 @@ setMethod("saveDatasheet",
 #' @rdname saveDatasheet
 setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), 
           function(ssimObject, data, name, append, force) {
-  browser()
-            
+
   # Check if we are currently running in a SyncroSim environment
   e <- ssimEnvironment()
   if (!is.na(e$TransferDirectory)) {
@@ -176,7 +175,8 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
     }
   }
 
-  # Convert NAs to empty strings
+  # Convert dataframe to characters and NAs to empty strings
+  data[] <- lapply(data, as.character)
   data[is.na(data)] <- ""
   
   # Save temporary datasheet CSV file
@@ -202,7 +202,8 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
   
   if (import) {
     
-    args <- list(import = NULL, lib = .filepath(ssimObject), sheet = name, file = tempFile)
+    args <- list(import = NULL, lib = .filepath(ssimObject), 
+                 sheet = name, file = tempFile)
     tt <- "saved"
     
     if (nrow(data) > 0) {

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -92,6 +92,7 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
     path <- e$TransferDirectory
   } else {
     import <- TRUE
+    path <- .tempfilepath(ssimObject)
   }
   
   # Set the append argument default
@@ -177,6 +178,24 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
 
   # Convert NAs to empty strings
   data[is.na(data)] <- ""
+  
+  # Save temporary datasheet CSV file
+  dir.create(path, showWarnings = FALSE, recursive = TRUE)
+  
+  if (append) {
+    tempFile <- paste0(path, "/", "SSIM_APPEND-", name, ".csv")
+  } else {
+    tempFile <- paste0(path, "/", "SSIM_OVERWRITE-", name, ".csv")
+  }
+  
+  if (nchar(tempFile) >= 260){
+    msg <- paste("path to temporary files generated at runtime is longer", 
+                 " than 260 characters. This may result in a connection ",
+                 "error if long paths are not enabled on Windows machines.")
+    updateRunLog(msg, type = "warning")
+  }
+  
+  write.csv(data, file = tempFile, row.names = FALSE, quote = TRUE)
 
   # If not running in SyncroSim env then import changes to ssim database
   if (import) {
@@ -206,27 +225,6 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
     
   } else {
     
-    # Set path to save temporary datasheet CSV files
-    if (is.null(path)) {
-      path <- .tempfilepath(ssimObject)
-    }
-    
-    dir.create(path, showWarnings = FALSE, recursive = TRUE)
-    
-    if (append) {
-      tempFile <- paste0(path, "/", "SSIM_APPEND-", name, ".csv")
-    } else {
-      tempFile <- paste0(path, "/", "SSIM_OVERWRITE-", name, ".csv")
-    }
-    
-    if (nchar(tempFile) >= 260){
-      msg <- paste("path to temporary files generated at runtime is longer", 
-                   " than 260 characters. This may result in a connection ",
-                   "error if long paths are not enabled on Windows machines.")
-      updateRunLog(msg, type = "warning")
-    }
-    
-    write.csv(data, file = tempFile, row.names = FALSE, quote = TRUE)
     out <- "Saved"
   }
   

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -3,53 +3,25 @@
 #' @include AAAClassDefinitions.R
 NULL
 
-#' Save Datasheet(s)
+#' Save datasheet
 #'
-#' Saves Datasheets to a \code{\link{SsimLibrary}}, \code{\link{Project}}, or 
+#' Saves a datasheet to a \code{\link{SsimLibrary}}, \code{\link{Project}}, or 
 #' \code{\link{Scenario}}.
 #' 
 #' @param ssimObject \code{\link{SsimLibrary}}, \code{\link{Project}}, or 
 #'     \code{\link{Scenario}} object
-#' @param data data.frame, named vector, or list of these. One or more 
-#'     Datasheets to load
-#' @param name character or vector of these. The name(s) of the Datasheet(s) to 
-#'     be saved. If a vector of names is provided, then a list must be provided 
-#'     for the \code{data} argument. Names provided here will override those provided 
-#'     with \code{data} argument's list
-#' @param fileData named list or SpatRaster object. Names are file names (without paths), 
-#'     corresponding to entries in \code{data} The elements are objects containing the 
-#'     data associated with each name. Currently supports terra SpatRaster objects as elements, 
-#'     (support for Raster objects is deprecated)
+#' @param data data.frame. The datasheet to load
+#' @param name character. The name of the datasheet to be saved
 #' @param append logical. If \code{TRUE}, the incoming data will be appended to the 
-#'     Datasheet if possible.  Default is \code{TRUE} for Project/SsimLibrary-scope Datasheets, 
+#'     datasheet if possible.  Default is \code{TRUE} for Project/SsimLibrary-scope datasheets, 
 #'     and \code{FALSE} for Scenario-scope Datasheets. See 'details' for more information 
 #'     about this argument
-#' @param forceElements logical. If \code{FALSE} (default) a single return message will 
-#'     be returned as a character string. Otherwise it will be returned in a list
-#' @param force logical. If Datasheet scope is Project/SsimLibrary, and \code{append=FALSE}, 
-#'     Datasheet will be deleted before loading the new data. This can also delete 
+#' @param force logical. If datasheet scope is Project/SsimLibrary, and \code{append=FALSE}, 
+#'     datasheet will be deleted before loading the new data. This can also delete 
 #'     other definitions and results, so if \code{force=FALSE} (default) user will be 
 #'     prompted for approval 
-#' @param breakpoint logical. Set to \code{TRUE} when modifying Datasheets in a 
-#'     breakpoint function. Default is \code{FALSE}
-#' @param import logical. Set to \code{TRUE} to import the data after saving. 
-#'     Default is \code{FALSE}
-#' @param path character.  output path (optional)
 #' 
 #' @details
-#' SsimObject/Project/Scenario should identify a single SsimObject.
-#'
-#' If \code{fileData != NULL}, each element of \code{names(fileData)} should correspond uniquely 
-#' to at most one entry in data. If a name is not found in data the element will 
-#' be ignored with a warning. If \code{names(fileData)} are full filepaths, rsyncrosim 
-#' will write each object to the corresponding path for subsequent loading by SyncroSim. 
-#' Note this is generally more time-consuming because the files must be written twice.
-#' If \code{names(fileData)} are not filepaths (faster, recommended), rsyncrosim will 
-#' write each element directly to the appropriate SyncroSim input/output folders.
-#' rsyncrosim will write each element of fileData directly to the appropriate 
-#' SyncroSim input/output folders. If \code{fileData != NULL}, data should be a data.frame, 
-#' vector, or list of length 1, not a list of length >1.
-#' 
 #' About the 'append' argument:
 #' 
 #' \itemize{
@@ -89,281 +61,164 @@ NULL
 #' saveDatasheet(ssimObject = myScenario, 
 #'               data = myDatasheet, 
 #'               name = "helloworldSpatial_RunControl")
-#'           
-#' # Import data after saving
-#' saveDatasheet(ssimObject = myScenario, 
-#'               data = myDatasheet, 
-#'               name = "helloworldSpatial_RunControl",
-#'               import = TRUE)
-#'         
-#' # Save the new Datasheet to a specified output path
-#' saveDatasheet(ssimObject = myScenario, 
-#'               data = myDatasheet, 
-#'               name = "helloworldSpatial_RunControl",
-#'               path = tempdir())
-#'               
-#' # Save a raster stack using fileData
-#' # Create a raster stack - add as many raster files as you want here
-#' map1 <- datasheetSpatRaster(myScenario, 
-#'                             datasheet = "helloworldSpatial_InputDatasheet",
-#'                             column = "InterceptRasterFile")
-#' inRasters <- terra::rast(map1)
 #' 
 #' # Change the name of the rasters in the input Datasheets to match the stack
 #' inSheet <- datasheet(myScenario, name = "helloworldSpatial_InputDatasheet")
 #' inSheet[1,"InterceptRasterFile"] <- names(inRasters)[1]
 #' 
-#' # Save the raster stack to the input Datasheet
-#' saveDatasheet(myScenario, data = inSheet, 
-#'               name = "helloworldSpatial_InputDatasheet", 
-#'               fileData = inRasters)
 #' }
 #' 
 #' @export
 setGeneric("saveDatasheet", 
-           function(ssimObject, data, name = NULL, fileData = NULL, 
-                    append = NULL, forceElements = FALSE, force = FALSE, 
-                    breakpoint = FALSE, import = TRUE, 
-                    path = NULL) standardGeneric("saveDatasheet"))
+           function(ssimObject, data, name = NULL, append = NULL, 
+                    force = FALSE) standardGeneric("saveDatasheet"))
 
 #' @rdname saveDatasheet
 setMethod("saveDatasheet", 
           signature(ssimObject = "character"), 
-          function(ssimObject, data, name, fileData, append, forceElements, 
-                   force, breakpoint, import, path) {
+          function(ssimObject, data, name, append, force) {
   return(SyncroSimNotFound(ssimObject))
 })
 
 #' @rdname saveDatasheet
 setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), 
-          function(ssimObject, data, name, fileData, append, forceElements, 
-                   force, breakpoint, import, path) {
+          function(ssimObject, data, name, append, force) {
+  browser()
+            
+  # Check if we are currently running in a SyncroSim environment
+  e <- ssimEnvironment()
+  if (!is.na(e$TransferDirectory)) {
+    import <- FALSE
+    path <- e$TransferDirectory
+  } else {
+    import <- TRUE
+  }
   
-  isFile <- NULL
-  x <- ssimObject
+  # Set the append argument default
   if (is.null(append)) {
-    if (is(x, "Scenario")) {
+    if (is(ssimObject, "Scenario")) {
       append <- FALSE
     } else {
       append <- TRUE
     }
   }
-
-  args <- list()
-  sheetNames <- .datasheets(x)
-
-  if (is.null(path)) {
-    e <- ssimEnvironment()
-    if (!is.na(e$TransferDirectory)) {
-      import <- FALSE
-      path <- e$TransferDirectory
+  
+  # If force not set to TRUE, then prompt user for project/library ds removal
+  if (!force & !append & (is(ssimObject, "Project")) | is(ssimObject, "Library")) {
+    message("Overwriting", name, 
+            " may result in data in linked scenario-scoped datasheets being removed as well.",
+            "\nAre you sure you want to overwrite ", name, "?")
+    answer <- readline(prompt = "(y/n):")
+    
+    if (answer == "n") {
+      append <- FALSE
     }
   }
 
-  # Note - cannot handle a list of named vectors, only a list of dataframes.
-  if ((!is(data, "list")) | (!is(data[[1]], "data.frame"))) {
-    if (is.null(name)) {
-      stop("Need a datasheet name.")
-    }
-    if (length(name) > 1) {
-      stop("If a vector of names is provided, then data must be a list.")
-    }
+  if (!grepl("_", name, fixed = T)) {
+    stop("The datasheet name requires a package prefix (e.g., 'stsim_RunControl')")
+  }
 
-    if (!grepl("_", name, fixed = T)) {
-      stop("The datasheet name requires a package prefix (e.g., 'stsim_RunControl')")
-    }
-
-    hdat <- data
-    data <- list()
-    data[[name]] <- hdat
-  } else {
-    if (!is.null(name)) {
-      if (length(name) != length(data)) {
-        stop("Please provide a name for each element of data.")
-      }
-      warning("Name argument will override names(data).")
-      names(data) <- name
-    } else {
-      name <- names(data)
+  # convert factors to strings
+  for (kk in seq(length.out = ncol(data))) {
+    if (is.factor(data[[kk]])) {
+      data[[kk]] <- as.character(data[[kk]])
     }
   }
 
-  if (!is.null(fileData) && (length(data) > 1)) {
-    stop("If fileData != NULL, data should be a dataframe, vector, or list of length 1.")
+  # Check whether datasheet provided actually exists.
+  sheetNames <- .datasheets(ssimObject)
+  scope <- sheetNames$scope[sheetNames$name == name]
+  if (length(scope) == 0) {
+    stop(paste0(name, " not found in available datasheets"))
   }
-  out <- list()
-  for (i in seq(length.out = length(data))) {
-    cName <- names(data)[i]
-    cDat <- data[[cName]]
+  
+  # Subset data by available columns
+  tt <- command(c("list", "columns", "csv", "allprops", 
+                  paste0("lib=", .filepath(ssimObject)), paste0("sheet=", name)), 
+                .session(ssimObject))
+  sheetInfo <- .dataframeFromSSim(tt)
+  
+  # Remove the Library/Project/Scenario ID from the datasheet
+  if (scope == "library"){
+    colsToKeep <- sheetInfo$name[!sheetInfo$name %in% c("LibraryId")]
+  } else if (scope == "project"){
+    colsToKeep <- sheetInfo$name[!sheetInfo$name %in% c("ProjectId")]
+  } else if (scope == "scenario"){
+    colsToKeep <- sheetInfo$name[!sheetInfo$name %in% c("ScenarioId")]
+  }
+  
+  # Remove the datasheet ID from the datasheet if it exists
+  dsInfo <- sheetNames[sheetNames$name == name,]
+  dsName <- gsub(paste0(dsInfo$package, "_"), '', dsInfo$name)
+  dsNameID <- paste0(dsName, "Id")
+  colsToKeep <- colsToKeep[!colsToKeep %in% c(dsNameID)]
+  
+  # Determine if any columns in incoming data do not exist in datasheet
+  unknownCols <- !colnames(data) %in% colsToKeep
+  if (any(unknownCols)) {
+    unknownCols <- colnames(data)[unknownCols]
+    stop(paste0("The following column does not exist in the datasheet: ", 
+                unknownCols))
+  }
+  
+  # Subset data by the valid columns
+  colsToKeep <- colnames(data)[colnames(data) %in% colsToKeep]
+  data <- data[colsToKeep]
 
-    # handle cases when cDat is not a data.frame
-    if (!is(cDat, "data.frame")) {
-      cIn <- cDat
-      if (length(cIn) == 0) {
-        stop("No data found for ", cName)
-      }
-      if (!is.null(names(cDat))) {
-        cDat <- data.frame(a = cIn[[1]])
-        names(cDat) <- names(cIn)[1]
-        for (j in seq(length.out = (length(cIn) - 1))) {
-          cDat[[names(cIn)[j + 1]]] <- cIn[[j + 1]]
-        }
-      } else {
-        stop() #handle this case
-      }
+  # Convert logicals to "Yes" or "No"
+  for (j in seq(length.out = ncol(data))) {
+    if (is.logical(data[[j]])) {
+      inCol <- data[[j]]
+      data[[j]][inCol] <- "Yes"
+      data[[j]][!inCol] <- "No"
     }
+  }
 
-    # convert factors to strings
-    for (kk in seq(length.out = ncol(cDat))) {
-      if (is.factor(cDat[[kk]])) {
-        cDat[[kk]] <- as.character(cDat[[kk]])
-      }
-    }
+  # Convert NAs to empty strings
+  data[is.na(data)] <- ""
 
-    # note deletions must happen before files are written.
-    scope <- sheetNames$scope[sheetNames$name == cName]
-    if (length(scope) == 0) {
-      sheetNames <- datasheets(x, core = TRUE)
-      scope <- sheetNames$scope[sheetNames$name == cName]
-      if (length(scope) == 0) {
-        stop("Name not found in datasheetNames")
-      }
-    }
+  # If not running in SyncroSim env then import changes to ssim database
+  if (import) {
     
-    # Subset data by available columns
-    tt <- command(c("list", "columns", "csv", "allprops", 
-                    paste0("lib=", .filepath(x)), paste0("sheet=", name)), 
-                  .session(x))
-    sheetInfo <- .dataframeFromSSim(tt)
+    args <- list(import = NULL, lib = .filepath(ssimObject), sheet = name, file = tempFile)
+    tt <- "saved"
     
-    # Remove the Library/Project/Scenario ID from the datasheet
-    if (scope == "library"){
-      colsToKeep <- sheetInfo$name[!sheetInfo$name %in% c("LibraryId")]
-    } else if (scope == "project"){
-      colsToKeep <- sheetInfo$name[!sheetInfo$name %in% c("ProjectId")]
-    } else if (scope == "scenario"){
-      colsToKeep <- sheetInfo$name[!sheetInfo$name %in% c("ScenarioId")]
-    }
-    
-    # Remove the datasheet ID from the datasheet if it exists
-    dsInfo <- sheetNames[sheetNames$name == cName,]
-    dsName <- gsub(paste0(dsInfo$package, "_"), '', dsInfo$name)
-    dsNameID <- paste0(dsName, "Id")
-    colsToKeep <- colsToKeep[!colsToKeep %in% c(dsNameID)]
-    
-    # Determine if any columns in incoming data do not exist in datasheet
-    unknownCols <- !colnames(cDat) %in% colsToKeep
-    if (any(unknownCols)) {
-      unknownCols <- colnames(cDat)[unknownCols]
-      stop(paste0("The following column does not exist in the datasheet: ", 
-                  unknownCols))
-    }
-    
-    # Subset data by the valid columns
-    colsToKeep <- colnames(cDat)[colnames(cDat) %in% colsToKeep]
-    cDat <- cDat[colsToKeep]
-
-    # if no fileData found and datasheet contains files, find the files
-    if (is.null(fileData)) {
-
-      if (sum(grepl("isExternalFile^True", sheetInfo$properties, fixed = TRUE)) > 0) {
-        sheetInfo$isFile <- grepl("isRaster^True", sheetInfo$properties, fixed = TRUE)
-      } else {
-        sheetInfo$isFile <- grepl("isExternalFile^Yes", sheetInfo$properties, fixed = TRUE)
-        # NOTE: this should be isExternalFile - but the flag is set to true even for non-files
+    if (nrow(data) > 0) {
+      
+      if (scope == "project") {
+        args[["pid"]] <- .projectId(ssimObject)
+        if (append) args <- c(args, list(append = NULL))
       }
       
-      sheetInfo <- subset(sheetInfo, isFile)
-      sheetInfo <- subset(sheetInfo, is.element(name, names(cDat)))
-    }
-
-    # Write items to appropriate locations
-    if (!is.null(fileData)) {
-      itemNames <- names(fileData)
-      if (is.null(itemNames) || is.na(itemNames) || (length(itemNames) == 0)) {
-        stop("names(fileData) must be defined, and each element must correspond uniquely to an entry in data")
+      if (scope == "scenario") {
+        args[["sid"]] <- .scenarioId(ssimObject)
+        if (append) args <- c(args, list(append = NULL))
       }
+      
+      tt <- command(args, .session(ssimObject))
+    }
     
-      sheetInfo <- subset(datasheet(x, summary = TRUE, optional = TRUE), name == cName)
-      fileDir <- .filepath(x)
-      fileDir <- paste0(fileDir, ".data")
-      fileDir <- paste0(fileDir, "/Scenario-", .scenarioId(x), "/", cName)
-
-      dir.create(fileDir, showWarnings = FALSE, recursive = TRUE)
-
-      for (j in seq(length.out = length(itemNames))) {
-        cFName <- itemNames[j]
-        cItem <- fileData[[cFName]]
-        
-        if (!is(cItem, "SpatRaster")){
-          stop("rsyncrosim currently only supports terra SpatRasters as elements of fileData.")
-        }
-
-        # check for cName in datasheet
-        findName <- cDat == cFName
-        findName[is.na(findName)] <- FALSE
-        sumFind <- sum(findName == TRUE, na.rm = TRUE)
-
-        if (sumFind > 1) {
-          stop("Each element of names(fileData) must correspond to at most one entry in data. ", sumFind, " entries of ", cName, " were found in data.")
-        }
-        if (sumFind == 0) {
-          warning(cName, " not found in data. This element will be ignored.")
-          next
-        }
-
-        if (identical(basename(cFName), cFName)) {
-          cOutName <- paste0(fileDir, "/", cFName)
-        } else {
-          cOutName <- cFName
-        }
-        if (!grepl(".tif", cOutName, fixed = TRUE)) {
-          cDat[findName] <- paste0(cDat[findName], ".tif")
-
-          cOutName <- paste0(cOutName, ".tif")
-        }
-
-        if (is(cItem, "SpatRaster")){
-          terra::writeRaster(cItem, cOutName, overwrite = TRUE)
-        }
-        
-        if (is(cItem, "RasterLayer")) {
-          stop("Functions from the raster package are no longer supported.")
-        }
-      }
+    if (tt[[1]] == "saved") {
+      unlink(tempFile)
     }
-    for (j in seq(length.out = ncol(cDat))) {
-      if (is.factor(cDat[[j]])) {
-        cDat[[j]] <- as.character(cDat[[j]])
-      }
-      if (is.logical(cDat[[j]])) {
-        inCol <- cDat[[j]]
-        cDat[[j]][inCol] <- "Yes"
-        cDat[[j]][!inCol] <- "No"
-      }
-    }
-
-    cDat[is.na(cDat)] <- ""
-    pathBit <- NULL
-
+    out <- tt
+    
+  } else {
+    
+    # Set path to save temporary datasheet CSV files
     if (is.null(path)) {
-      if (breakpoint) {
-        pathBit <- paste0(.filepath(x), ".temp/Data")
-      } else {
-        pathBit <- .tempfilepath(x)
-      }
-    } else {
-      pathBit <- path
+      path <- .tempfilepath(ssimObject)
     }
-
-    dir.create(pathBit, showWarnings = FALSE, recursive = TRUE)
-
+    
+    dir.create(path, showWarnings = FALSE, recursive = TRUE)
+    
     if (append) {
-      tempFile <- paste0(pathBit, "/", "SSIM_APPEND-", cName, ".csv")
+      tempFile <- paste0(path, "/", "SSIM_APPEND-", name, ".csv")
     } else {
-      tempFile <- paste0(pathBit, "/", "SSIM_OVERWRITE-", cName, ".csv")
+      tempFile <- paste0(path, "/", "SSIM_OVERWRITE-", name, ".csv")
     }
-
+    
     if (nchar(tempFile) >= 260){
       msg <- paste("path to temporary files generated at runtime is longer", 
                    " than 260 characters. This may result in a connection ",
@@ -371,53 +226,20 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
       updateRunLog(msg, type = "warning")
     }
     
-    write.csv(cDat, file = tempFile, row.names = FALSE, quote = TRUE)
-    if (breakpoint) {
-      out[[cName]] <- "Saved"
-      next
-    }
-
-    if (import) {
-      args <- list(import = NULL, lib = .filepath(x), sheet = cName, file = tempFile)
-      tt <- "saved"
-      
-      if (nrow(cDat) > 0) {
-        
-        if (scope == "project") {
-          args[["pid"]] <- .projectId(x)
-          if (append) args <- c(args, list(append = NULL))
-        }
-        
-        if (scope == "scenario") {
-          args[["sid"]] <- .scenarioId(x)
-          if (append) args <- c(args, list(append = NULL))
-        }
-        
-        tt <- command(args, .session(x))
-      }
-      
-      if (tt[[1]] == "saved") {
-        unlink(tempFile)
-      }
-      out[[cName]] <- tt
-      
-    } else {
-      out[[cName]] <- "Saved"
-    }
-    
-    if (out[[cName]][1] == "saved"){
-      message(paste0("Datasheet <",cName, "> saved"))
-      out[[cName]] <- TRUE
-    } else {
-      message(out[[cName]])
-      out[[cName]] <- FALSE
-    }
-    
+    write.csv(data, file = tempFile, row.names = FALSE, quote = TRUE)
+    out <- "Saved"
   }
   
-  if (!forceElements && (length(out) == 1)) {
-    out <- out[[1]]
+  if (out == "saved"){
+    message(paste0("Datasheet <",name, "> saved"))
+    out <- TRUE
+  } else {
+    message(out)
+    out <- FALSE
   }
-  unlink(.tempfilepath(x), recursive = TRUE)
+  
+  # Clean up temporary files
+  unlink(.tempfilepath(ssimObject), recursive = TRUE)
+  
   return(invisible(out))
 })


### PR DESCRIPTION
Refactored `saveDatasheet()` to be much simpler and removed the following unused arguments:
  * `fileData`
  * `forceElements`
  * `breakpoint`
  * `import`
  * `path`

Also fixed a bug that happens when a dataframe columns of type double contain both NAs and values and you try to use `saveDatasheet()` on it.