### PR TITLE
Fix overwriting of invisible columns on datasheet save

### DIFF
--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -163,8 +163,11 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
   }
   
   # Add invisible columns to data to ensure they are not overwritten
-  originalData <- .datasheet(ssimObject, name, returnInvisible = T)
-  data <- merge(data, originalData, all = T)
+  # if datasheet is possibly a validation source
+  if ((scope == "project") & (append != FALSE)) {
+    originalData <- .datasheet(ssimObject, name, returnInvisible = T)
+    data <- merge(data, originalData, all = T)
+  }
   
   # Subset data by the valid columns
   colsToKeep <- colnames(data)[colnames(data) %in% colsToKeep]

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -164,9 +164,10 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
   
   # Add invisible columns to data to ensure they are not overwritten
   # if datasheet is possibly a validation source
+  # Remove rows that already exist in the dataframe
   if ((scope == "project") & (append != FALSE)) {
     originalData <- .datasheet(ssimObject, name, returnInvisible = T)
-    data <- merge(data, originalData, all = T)
+    data <- merge(data, originalData, all.x = T)
   }
   
   # Subset data by the valid columns

--- a/R/saveDatasheet.R
+++ b/R/saveDatasheet.R
@@ -79,7 +79,6 @@ setMethod("saveDatasheet",
 setMethod("saveDatasheet", signature(ssimObject = "SsimObject"), 
           function(ssimObject, data, name, append, force) {
   
-            
   # Check if data is in correct format
   if (!is.data.frame(data)) {
     stop("data must be in R data.frame format.")
@@ -162,6 +161,10 @@ setMethod("saveDatasheet", signature(ssimObject = "SsimObject"),
     stop(paste0("The following column does not exist in the datasheet: ", 
                 unknownCols))
   }
+  
+  # Add invisible columns to data to ensure they are not overwritten
+  originalData <- .datasheet(ssimObject, name, returnInvisible = T)
+  data <- merge(data, originalData, all = T)
   
   # Subset data by the valid columns
   colsToKeep <- colnames(data)[colnames(data) %in% colsToKeep]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves hidden/invisible columns when saving project-scoped datasheets with append enabled by merging existing datasheet data into incoming data before saving. Prevents accidental loss of non-visible fields and maintains full column integrity across saves. No change to how you invoke the save action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->