### PR TITLE
Ha fix duplicate datasheet output

### DIFF
--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -606,7 +606,12 @@ setMethod("datasheet",
       # Policy change - always query output directly from database. It is faster.
       useConsole <- useConsole & ((sqlStatement$select == "SELECT *")) # &(!lookupsAsFactors))
       useConsole <- useConsole & !((sheetNames$scope == "project") & (length(pid) > 1))
-      useConsole <- useConsole & !((sheetNames$scope == "scenario") & (length(sid) > 1))
+      # Force DB query for multi-scenario sheets (console export loses ScenarioId!)
+      if (sheetNames$scope == "scenario" && length(sid) > 1) {
+          useConsole <- FALSE
+      } else {
+          useConsole <- TRUE
+      }
       # => These send you to query building (case for BOTH fastQuery and UseConsole are FALSE) if :
       # sql statement is complex, or more than one proj/sce is provided
       
@@ -755,6 +760,8 @@ setMethod("datasheet",
               stop(tt)
             }
 
+            cat("CONSOLE EXPORT path\n")
+
             sheet <- read.csv(tempFile, as.is = TRUE, encoding = "UTF-8")
             
             cat("Rows/Cols after import:", nrow(sheet), ncol(sheet), "\n")
@@ -805,6 +812,10 @@ setMethod("datasheet",
         
         sql <- paste(sqlStatement$select, sqlStatement$from, sqlStatement$where, sqlStatement$groupBy)
         sheet <- DBI::dbGetQuery(con, sql)
+        # Normalize DB column names to expected SyncroSim case conventions
+        names(sheet) <- sub("^ScenarioID$", "ScenarioId", names(sheet), ignore.case = TRUE)
+        names(sheet) <- sub("^ProjectID$",  "ProjectId", names(sheet), ignore.case = TRUE)
+        cat("DB query path: columns = ", paste(names(sheet), collapse=", "), "\n")
         DBI::dbDisconnect(con)
 
         cat("Rows/Cols after import:", nrow(sheet), ncol(sheet), "\n")
@@ -893,31 +904,60 @@ setMethod("datasheet",
           ))
         }
         
-        # Fix for multi-scenario support
+        # ------------------------------
+        # ScenarioId Handling (correct)
+        # ------------------------------
+        if (cRow$name == "ScenarioId") {
+
+            # DB query path (multi or single scenario)
+            # DB output already contains ScenarioId (after earlier normalization)
+            if ("ScenarioId" %in% names(sheet)) {
+                outNames <- c(outNames, "ScenarioId")
+                next
+            }
+
+            # Console export: multi-scenario
+            # Console never returns ScenarioId for >1 scenario
+            # Leave NA to be filled later during merge with allScns
+            if (length(sid) > 1) {
+                sheet$ScenarioId <- NA_integer_
+                outNames <- c(outNames, "ScenarioId")
+                next
+            }
+
+            # Console export: single scenario
+            # Console output missing ScenarioId → fill with scalar sid
+            if (length(sid) == 1) {
+                sheet$ScenarioId <- rep(sid, nrow(sheet))
+                outNames <- c(outNames, "ScenarioId")
+                next
+            }
+
+            # Fallback (should never be hit)
+            sheet$ScenarioId <- NA_integer_
+            outNames <- c(outNames, "ScenarioId")
+            next
+        }
+
+
+        # ------------------------------
+        # Non-ScenarioId handling
+        # Only fill missing columns when needed
+        # ------------------------------
         if (!is.element(cRow$name, colnames(sheet))) {
 
-          # --- ScenarioId Fix ---
-          if (cRow$name == "ScenarioId") {
-
-            # Case 1: Multiple scenarios → leave missing here
-            # We will insert ScenarioId correctly later during merge.
-            if (length(sid) > 1) {
-              sheet[[cRow$name]] <- NA_integer_
-            
-            # Case 2: Single scenario → fill with scalar repeated for all rows
-            } else if (length(sid) == 1) {
-              sheet[[cRow$name]] <- rep(sid, nrow(sheet))
-            
+            # For SELECT * queries, missing columns become NA
+            if (sqlStatement$select == "SELECT *") {
+                sheet[[cRow$name]] <- NA
+                outNames <- c(outNames, cRow$name)
+                next
             }
-          
-          # --- Everything else ---
-          } else if (sqlStatement$select == "SELECT *") {
-            sheet[[cRow$name]] <- NA
-          } else {
+
+            # Otherwise skip; column to be ignored
             next
-          }
         }
-        
+
+        # If we reach here, column already exists; include in outNames
         outNames <- c(outNames, cRow$name)
         
         if ((cRow$type %in% c("Integer", "Double", "Single")) & !(cRow$valType %in% c("DataSheet", "List"))) {
@@ -1106,8 +1146,13 @@ setMethod("datasheet",
         names(allScns) <- c("ScenarioId", "ProjectId", "ScenarioName", "ParentId", "ParentName")
         allScns <- allScns[allScns$ScenarioId %in% sid,]
         
-        sheet <- sheet[, !(names(sheet) %in% "ScenarioId")]
-        sheet <- merge(allScns, sheet, all.y = TRUE)
+        # KEEP ScenarioId in sheet for multi-scenario joins
+        # Only drop ScenarioId if single-scenario extraction
+        if (length(sid) == 1) {
+            sheet$ScenarioId <- NULL
+        }
+        # FIX: join by ScenarioId only
+        sheet <- merge(allScns, sheet, by = "ScenarioId", all.y = TRUE)
       }
     }
     

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -185,64 +185,48 @@ setGeneric("datasheet", function(ssimObject, name = NULL, project = NULL, scenar
 
 # Handles case where ssimObject is list of Scenario or Project objects
 #' @rdname datasheet
-setMethod("datasheet",
-          signature(ssimObject = "list"),
-          function(ssimObject, name, project, scenario, summary, optional, empty,
-                   filterColumn, filterValue, lookupsAsFactors, sqlStatement,
+setMethod("datasheet", 
+          signature(ssimObject = "list"), 
+          function(ssimObject, name, project, scenario, summary, optional, empty, 
+                   filterColumn, filterValue, lookupsAsFactors, sqlStatement, 
                    includeKey, forceElements, fastQuery, returnScenarioInfo,
                    returnInvisible, rawValues, verbose) {
+  
+  print("=== In datasheet method for list ===")
 
-            # Determine type of list contents
-            first <- ssimObject[[1]]
-
-            if (is(first, "Scenario")) {
-                x <- getIdsFromListOfObjects(
-                    ssimObject,
-                    expecting = "Scenario",
-                    scenario = NULL,
-                    project = NULL
-                )
-                lib <- x$ssimObject
-                scenarios <- x$objs
-                projects <- NULL
-            } else if (is(first, "Project")) {
-              x <- getIdsFromListOfObjects(
-                  ssimObject,
-                  expecting = "Project",
-                    scenario = NULL,
-                    project = NULL
-              )
-                lib <- x$ssimObject
-                projects <- x$objs
-                scenarios <- NULL
-            } else {
-              stop("List must contain Scenario or Project objects.")
-            }
-
-            # Now call core datasheet function with explicit multi-scenario vector
-            out <- .datasheet(
-                lib,
-                name = name,
-                project = projects,
-                scenario = scenarios,
-                summary = summary,
-                optional = optional,
-                empty = empty,
-                filterColumn = filterColumn,
-                filterValue = filterValue,
-                lookupsAsFactors = lookupsAsFactors,
-                sqlStatement = sqlStatement,
-                includeKey = includeKey,
-                forceElements = forceElements,
-                fastQuery = fastQuery,
-                returnScenarioInfo = TRUE,
-                returnInvisible = returnInvisible,
-                rawValues = rawValues,
-                verbose = verbose
-            )
-
-            return(out)
-          })
+  cScn <- ssimObject[[1]]
+  x <- NULL
+  
+  if (is(cScn, "Scenario")) {
+    x <- getIdsFromListOfObjects(ssimObject, expecting = "Scenario", scenario = scenario, project = project)
+    scenario <- x$objs
+    project <- NULL
+  }
+  
+  if (is(cScn, "Project")) {
+    x <- getIdsFromListOfObjects(ssimObject, expecting = "Project", scenario = scenario, project = project)
+    project <- x$objs
+    scenario <- NULL
+  }
+  
+  ssimObject <- x$ssimObject
+  
+  if (is.null(ssimObject)) {
+    stop("Expecting ssimObject to be an SsimLibrary/Project/Scenario, or a list of Scenarios/Projects.")
+  }
+  # Now have scenario/project ids of same type in same library, and ssimObject is library
+  
+  out <- .datasheet(ssimObject, name = name, project = project, scenario = scenario, 
+                    summary = summary, optional = optional, empty = empty, 
+                    filterColumn = filterColumn, filterValue = filterValue, 
+                    lookupsAsFactors = lookupsAsFactors, sqlStatement = sqlStatement, 
+                    includeKey = includeKey, forceElements = forceElements, 
+                    fastQuery = fastQuery, returnScenarioInfo = returnScenarioInfo,
+                    returnInvisible = returnInvisible, rawValues = rawValues,
+                    verbose = verbose)
+  
+  return(out)
+})
 
 #' @rdname datasheet
 setMethod("datasheet", 
@@ -272,56 +256,84 @@ setMethod("datasheet",
   xProjScn <- .getFromXProjScn(ssimObject, project, scenario, returnIds = TRUE, 
                                convertObject = FALSE, complainIfMissing = TRUE)
 
+  print("=== In datasheet method for SsimObject ===")
+  print("=== After .getFromXProjScn ===")
+
+  IDColumns <- c("ScenarioId", "ProjectId")
   
   # -------------------------------------------------------------------------
-  # 1. GOAL-BASED INITIALIZATION
+  # NEW: Goal-based scope detection (fixes multi-scenario logic)
   # -------------------------------------------------------------------------
 
-  # goal is one of: "library", "project", "scenario"
-  scopeDS <- xProjScn$goal  
+  # xProjScn always contains:
+  #   $ssimObject
+  #   $project
+  #   $scenario
+  #   $scenarioSet
+  #   $goal  ← THIS is the correct source of truth
 
-  # Extract initial pid/sid from getFromXProjScn
+  scopeDS <- xProjScn$goal
+  x <- NULL
+  pid <- NULL
+  sid <- NULL
+
   if (is(xProjScn, "SsimLibrary")) {
-      x <- xProjScn           # library object itself
+      # Library-level call
+      x <- xProjScn
       pid <- NULL
       sid <- NULL
   } else {
+      # Project/scenario-level call
       x <- xProjScn$ssimObject
       pid <- xProjScn$project
       sid <- xProjScn$scenario
+
+      # If scenarios were provided, ensure project IDs align
+      if (!is.null(sid) & is.null(pid)) {
+          pid <- subset(xProjScn$scenarioSet, ScenarioId %in% sid)$ProjectId
+      }
   }
 
+  cat("DEBUG: Goal-based initialization\n")
+  print(list(goal = scopeDS, pid = pid, sid = sid))
+
   # -------------------------------------------------------------------------
-  # 2. HANDLE scenarioSet WHEN LISTS OR MULTI-ID INPUTS ARE INVOLVED
+  # Override using scenarioSet (handles lists and multi-scenario inputs)
   # -------------------------------------------------------------------------
 
   if (!is.null(xProjScn$scenarioSet)) {
+
       scenarioSet <- xProjScn$scenarioSet
 
-      # If user supplied no explicit scenario IDs, use scenarioSet
+      cat("DEBUG: scenarioSet detected\n")
+      print(head(scenarioSet))
+
+      # If user did not explicitly specify scenarios, derive them
       if (is.null(scenario)) {
           sid <- unique(scenarioSet$ScenarioId)
           pid <- unique(scenarioSet$ProjectId)
       }
 
-      # Multi-scenario override
+      # MULTI-SCENARIO → enforce scenario scope
       if (length(unique(scenarioSet$ScenarioId)) > 1) {
           scopeDS <- "scenario"
           returnScenarioInfo <- TRUE
+          cat("DEBUG: Multi-scenario override triggered\n")
       }
 
-      # Multi-project override (only if not multi-scenario)
+      # MULTI-PROJECT but not multi-scenario
       if (length(unique(scenarioSet$ProjectId)) > 1 &&
           length(unique(scenarioSet$ScenarioId)) == 1) {
           scopeDS <- "project"
+          cat("DEBUG: Multi-project override triggered\n")
       }
   }
 
   # -------------------------------------------------------------------------
-  # 3. FINAL SAFETY FIXES
+  # Respect explicit scenario / project arguments
   # -------------------------------------------------------------------------
 
-  # If user passed explicit scenario vector, respect it
+  # Explicit scenario override
   if (!missing(scenario) && !is.null(scenario)) {
       sid <- scenario
       if (length(scenario) > 1) {
@@ -330,7 +342,7 @@ setMethod("datasheet",
       }
   }
 
-  # If user passed explicit project vector, respect it
+  # Explicit project override
   if (!missing(project) && !is.null(project)) {
       pid <- project
       if (length(project) > 1) {
@@ -338,48 +350,9 @@ setMethod("datasheet",
       }
   }
 
-  # Debug (optional)
-  print(list(scopeDS=scopeDS, sid=sid, pid=pid))
+  cat("DEBUG: Final pid/sid/scope after overrides:\n")
+  print(list(scope = scopeDS, pid = pid, sid = sid))
   # -------------------------------------------------------------------------
-  
-  # # If user explicitly supplied scenario IDs → trust them
-  # if (!missing(scenario) && !is.null(scenario)) {
-  #     sid <- scenario
-  # }
-
-  # # Auto-detect multi-scenario ONLY IF:
-  # #   - user did NOT specify scenario IDs
-  # #   - but xProjScn$scenario already contains multiple IDs
-  # if (is.null(scenario) && length(xProjScn$scenario) > 1) {
-  #     sid <- xProjScn$scenario
-  #     pid <- xProjScn$project
-  #     message("datasheet(): Using multi-scenario mode (list or vector detected).")
-  # }
-
-  IDColumns <- c("ScenarioId", "ProjectId")
-  
-  # if (is(ssimObject, "SsimLibrary")){
-  #   scopeDS <- "library"
-  # } else if (is(ssimObject, "Project")){
-  #   scopeDS <- "project"
-  # } else {
-  #   scopeDS <- "scenario"
-  # }
-  
-  # if (is(xProjScn, "SsimLibrary")) {
-  #   x <- xProjScn
-  #   pid <- NULL
-  #   sid <- NULL
-  #   scopeDS <- "library"
-  # } else {
-  #   x <- xProjScn$ssimObject
-  #   pid <- xProjScn$project
-  #   sid <- xProjScn$scenario
-
-  #   if (!is.null(sid) & is.null(pid)) {
-  #     pid <- subset(xProjScn$scenarioSet, is.element(ScenarioId, sid))$ProjectId
-  #   }
-  # }
   
   # now have valid pid/sid vectors and x is library.
   if (!is.null(name)) {
@@ -512,6 +485,9 @@ setMethod("datasheet",
   
   # Loop through all datasheet names
   for (kk in seq(length.out = length(allNames))) {
+
+    cat("\n=== Processing sheet:", name, "===\n")
+    print(list(pid = pid, sid = sid, sheetScope = scopeDS))
     
     if (summary == FALSE) {
       
@@ -634,12 +610,6 @@ setMethod("datasheet",
       # => These send you to query building (case for BOTH fastQuery and UseConsole are FALSE) if :
       # sql statement is complex, or more than one proj/sce is provided
       
-      # --- FORCE PER-SCENARIO EXPORT WHEN MULTIPLE SIDs PRESENT ---
-      if (!is.null(sid) && length(sid) > 1) {
-          useConsole <- TRUE      # console export path
-          fastQuery <- TRUE       # force per-scenario query & smartbind
-      }
-
       if (useConsole | fastQuery) {
         unlink(tempFile)
         
@@ -786,6 +756,8 @@ setMethod("datasheet",
             }
 
             sheet <- read.csv(tempFile, as.is = TRUE, encoding = "UTF-8")
+            
+            cat("Rows/Cols after import:", nrow(sheet), ncol(sheet), "\n")
           }
         }
         
@@ -834,6 +806,8 @@ setMethod("datasheet",
         sql <- paste(sqlStatement$select, sqlStatement$from, sqlStatement$where, sqlStatement$groupBy)
         sheet <- DBI::dbGetQuery(con, sql)
         DBI::dbDisconnect(con)
+
+        cat("Rows/Cols after import:", nrow(sheet), ncol(sheet), "\n")
         
         # Filter out columns without data (drop NA columns) 
         if (!optional && (nrow(sheet) > 0)) {
@@ -907,28 +881,41 @@ setMethod("datasheet",
       }
       
       for (i in seq(length.out = nrow(sheetInfo))) {
-        
+
         cRow <- sheetInfo[i, ]
+
+        if (cRow$name == "ScenarioId") {
+          cat("*** About to assign ScenarioId ***\n")
+          print(list(
+            sid = sid,
+            sheet_nrows = nrow(sheet),
+            existing_col = sheet[["ScenarioId"]]
+          ))
+        }
         
-        # Correctly assign ScenarioId when missing
+        # Fix for multi-scenario support
         if (!is.element(cRow$name, colnames(sheet))) {
-            if (cRow$name == "ScenarioId") {
 
-                if (length(sid) == 1) {
-                    # Single scenario → fill entire column
-                    sheet$ScenarioId <- sid
-                } else {
-                    # Multi-scenario → sheet must already include ScenarioId from SQL export
-                    # or from fastQuery mode. If not, we must split by scenario.
-                    stop("ERROR: Multi-scenario datasheet did not contain per-row ScenarioId. 
-                          This sheet must be exported per scenario to preserve row identity.")
-                }
+          # --- ScenarioId Fix ---
+          if (cRow$name == "ScenarioId") {
 
-            } else if (sqlStatement$select == "SELECT *") {
-                sheet[[cRow$name]] <- NA
-            } else {
-                next
+            # Case 1: Multiple scenarios → leave missing here
+            # We will insert ScenarioId correctly later during merge.
+            if (length(sid) > 1) {
+              sheet[[cRow$name]] <- NA_integer_
+            
+            # Case 2: Single scenario → fill with scalar repeated for all rows
+            } else if (length(sid) == 1) {
+              sheet[[cRow$name]] <- rep(sid, nrow(sheet))
+            
             }
+          
+          # --- Everything else ---
+          } else if (sqlStatement$select == "SELECT *") {
+            sheet[[cRow$name]] <- NA
+          } else {
+            next
+          }
         }
         
         outNames <- c(outNames, cRow$name)
@@ -1012,7 +999,8 @@ setMethod("datasheet",
             }
             if (nrow(lookupSheet) > 0) {
               lookupSheet <- lookupSheet[order(lookupSheet[[names(lookupSheet[1])]]), ]
-              lookupLevels <- lookupSheet[[displayMem]]
+              # Ensure factor levels are unique to avoid "duplicated levels" error
+              lookupLevels <- unique(lookupSheet[[displayMem]])
             } else {
               lookupLevels <- c()
             }
@@ -1086,6 +1074,10 @@ setMethod("datasheet",
       }
     }
     if (is.element("ScenarioId", names(sheet))) {
+
+      cat("ScenarioId handling block: before merge\n")
+      print(head(sheet))
+
       if (length(sid) > 1){
         returnScenarioInfo <- TRUE
       }

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -185,46 +185,64 @@ setGeneric("datasheet", function(ssimObject, name = NULL, project = NULL, scenar
 
 # Handles case where ssimObject is list of Scenario or Project objects
 #' @rdname datasheet
-setMethod("datasheet", 
-          signature(ssimObject = "list"), 
-          function(ssimObject, name, project, scenario, summary, optional, empty, 
-                   filterColumn, filterValue, lookupsAsFactors, sqlStatement, 
+setMethod("datasheet",
+          signature(ssimObject = "list"),
+          function(ssimObject, name, project, scenario, summary, optional, empty,
+                   filterColumn, filterValue, lookupsAsFactors, sqlStatement,
                    includeKey, forceElements, fastQuery, returnScenarioInfo,
                    returnInvisible, rawValues, verbose) {
-  
-  cScn <- ssimObject[[1]]
-  x <- NULL
-  
-  if (is(cScn, "Scenario")) {
-    x <- getIdsFromListOfObjects(ssimObject, expecting = "Scenario", scenario = scenario, project = project)
-    scenario <- x$objs
-    project <- NULL
-  }
-  
-  if (is(cScn, "Project")) {
-    x <- getIdsFromListOfObjects(ssimObject, expecting = "Project", scenario = scenario, project = project)
-    project <- x$objs
-    scenario <- NULL
-  }
-  
-  ssimObject <- x$ssimObject
-  
-  if (is.null(ssimObject)) {
-    stop("Expecting ssimObject to be an SsimLibrary/Project/Scenario, or a list of Scenarios/Projects.")
-  }
-  # Now have scenario/project ids of same type in same library, and ssimObject is library
-  
-  out <- .datasheet(ssimObject, name = name, project = project, scenario = scenario, 
-                    summary = summary, optional = optional, empty = empty, 
-                    filterColumn = filterColumn, filterValue = filterValue, 
-                    lookupsAsFactors = lookupsAsFactors, sqlStatement = sqlStatement, 
-                    includeKey = includeKey, forceElements = forceElements, 
-                    fastQuery = fastQuery, returnScenarioInfo = returnScenarioInfo,
-                    returnInvisible = returnInvisible, rawValues = rawValues,
-                    verbose = verbose)
-  
-  return(out)
-})
+
+            # Determine type of list contents
+            first <- ssimObject[[1]]
+
+            if (is(first, "Scenario")) {
+                x <- getIdsFromListOfObjects(
+                    ssimObject,
+                    expecting = "Scenario",
+                    scenario = NULL,
+                    project = NULL
+                )
+                lib <- x$ssimObject
+                scenarios <- x$objs
+                projects <- NULL
+            } else if (is(first, "Project")) {
+              x <- getIdsFromListOfObjects(
+                  ssimObject,
+                  expecting = "Project",
+                    scenario = NULL,
+                    project = NULL
+              )
+                lib <- x$ssimObject
+                projects <- x$objs
+                scenarios <- NULL
+            } else {
+              stop("List must contain Scenario or Project objects.")
+            }
+
+            # Now call core datasheet function with explicit multi-scenario vector
+            out <- .datasheet(
+                lib,
+                name = name,
+                project = projects,
+                scenario = scenarios,
+                summary = summary,
+                optional = optional,
+                empty = empty,
+                filterColumn = filterColumn,
+                filterValue = filterValue,
+                lookupsAsFactors = lookupsAsFactors,
+                sqlStatement = sqlStatement,
+                includeKey = includeKey,
+                forceElements = forceElements,
+                fastQuery = fastQuery,
+                returnScenarioInfo = TRUE,
+                returnInvisible = returnInvisible,
+                rawValues = rawValues,
+                verbose = verbose
+            )
+
+            return(out)
+          })
 
 #' @rdname datasheet
 setMethod("datasheet", 
@@ -253,30 +271,115 @@ setMethod("datasheet",
   Name <- NULL
   xProjScn <- .getFromXProjScn(ssimObject, project, scenario, returnIds = TRUE, 
                                convertObject = FALSE, complainIfMissing = TRUE)
+
+  
+  # -------------------------------------------------------------------------
+  # 1. GOAL-BASED INITIALIZATION
+  # -------------------------------------------------------------------------
+
+  # goal is one of: "library", "project", "scenario"
+  scopeDS <- xProjScn$goal  
+
+  # Extract initial pid/sid from getFromXProjScn
+  if (is(xProjScn, "SsimLibrary")) {
+      x <- xProjScn           # library object itself
+      pid <- NULL
+      sid <- NULL
+  } else {
+      x <- xProjScn$ssimObject
+      pid <- xProjScn$project
+      sid <- xProjScn$scenario
+  }
+
+  # -------------------------------------------------------------------------
+  # 2. HANDLE scenarioSet WHEN LISTS OR MULTI-ID INPUTS ARE INVOLVED
+  # -------------------------------------------------------------------------
+
+  if (!is.null(xProjScn$scenarioSet)) {
+      scenarioSet <- xProjScn$scenarioSet
+
+      # If user supplied no explicit scenario IDs, use scenarioSet
+      if (is.null(scenario)) {
+          sid <- unique(scenarioSet$ScenarioId)
+          pid <- unique(scenarioSet$ProjectId)
+      }
+
+      # Multi-scenario override
+      if (length(unique(scenarioSet$ScenarioId)) > 1) {
+          scopeDS <- "scenario"
+          returnScenarioInfo <- TRUE
+      }
+
+      # Multi-project override (only if not multi-scenario)
+      if (length(unique(scenarioSet$ProjectId)) > 1 &&
+          length(unique(scenarioSet$ScenarioId)) == 1) {
+          scopeDS <- "project"
+      }
+  }
+
+  # -------------------------------------------------------------------------
+  # 3. FINAL SAFETY FIXES
+  # -------------------------------------------------------------------------
+
+  # If user passed explicit scenario vector, respect it
+  if (!missing(scenario) && !is.null(scenario)) {
+      sid <- scenario
+      if (length(scenario) > 1) {
+          scopeDS <- "scenario"
+          returnScenarioInfo <- TRUE
+      }
+  }
+
+  # If user passed explicit project vector, respect it
+  if (!missing(project) && !is.null(project)) {
+      pid <- project
+      if (length(project) > 1) {
+          scopeDS <- "project"
+      }
+  }
+
+  # Debug (optional)
+  print(list(scopeDS=scopeDS, sid=sid, pid=pid))
+  # -------------------------------------------------------------------------
+  
+  # # If user explicitly supplied scenario IDs → trust them
+  # if (!missing(scenario) && !is.null(scenario)) {
+  #     sid <- scenario
+  # }
+
+  # # Auto-detect multi-scenario ONLY IF:
+  # #   - user did NOT specify scenario IDs
+  # #   - but xProjScn$scenario already contains multiple IDs
+  # if (is.null(scenario) && length(xProjScn$scenario) > 1) {
+  #     sid <- xProjScn$scenario
+  #     pid <- xProjScn$project
+  #     message("datasheet(): Using multi-scenario mode (list or vector detected).")
+  # }
+
   IDColumns <- c("ScenarioId", "ProjectId")
   
-  if (is(ssimObject, "SsimLibrary")){
-    scopeDS <- "library"
-  } else if (is(ssimObject, "Project")){
-    scopeDS <- "project"
-  } else {
-    scopeDS <- "scenario"
-  }
+  # if (is(ssimObject, "SsimLibrary")){
+  #   scopeDS <- "library"
+  # } else if (is(ssimObject, "Project")){
+  #   scopeDS <- "project"
+  # } else {
+  #   scopeDS <- "scenario"
+  # }
   
-  if (is(xProjScn, "SsimLibrary")) {
-    x <- xProjScn
-    pid <- NULL
-    sid <- NULL
-    scopeDS <- "library"
-  } else {
-    x <- xProjScn$ssimObject
-    pid <- xProjScn$project
-    sid <- xProjScn$scenario
-    
-    if (!is.null(sid) & is.null(pid)) {
-      pid <- subset(xProjScn$scenarioSet, is.element(ScenarioId, sid))$ProjectId
-    }
-  }
+  # if (is(xProjScn, "SsimLibrary")) {
+  #   x <- xProjScn
+  #   pid <- NULL
+  #   sid <- NULL
+  #   scopeDS <- "library"
+  # } else {
+  #   x <- xProjScn$ssimObject
+  #   pid <- xProjScn$project
+  #   sid <- xProjScn$scenario
+
+  #   if (!is.null(sid) & is.null(pid)) {
+  #     pid <- subset(xProjScn$scenarioSet, is.element(ScenarioId, sid))$ProjectId
+  #   }
+  # }
   
   # now have valid pid/sid vectors and x is library.
   if (!is.null(name)) {
@@ -531,6 +634,12 @@ setMethod("datasheet",
       # => These send you to query building (case for BOTH fastQuery and UseConsole are FALSE) if :
       # sql statement is complex, or more than one proj/sce is provided
       
+      # --- FORCE PER-SCENARIO EXPORT WHEN MULTIPLE SIDs PRESENT ---
+      if (!is.null(sid) && length(sid) > 1) {
+          useConsole <- TRUE      # console export path
+          fastQuery <- TRUE       # force per-scenario query & smartbind
+      }
+
       if (useConsole | fastQuery) {
         unlink(tempFile)
         
@@ -801,14 +910,25 @@ setMethod("datasheet",
         
         cRow <- sheetInfo[i, ]
         
+        # Correctly assign ScenarioId when missing
         if (!is.element(cRow$name, colnames(sheet))) {
-          if (cRow$name == "ScenarioId"){
-            sheet[[cRow$name]] <- sid
-          } else if (sqlStatement$select == "SELECT *") {
-            sheet[[cRow$name]] <- NA
-          } else {
-            next
-          }
+            if (cRow$name == "ScenarioId") {
+
+                if (length(sid) == 1) {
+                    # Single scenario → fill entire column
+                    sheet$ScenarioId <- sid
+                } else {
+                    # Multi-scenario → sheet must already include ScenarioId from SQL export
+                    # or from fastQuery mode. If not, we must split by scenario.
+                    stop("ERROR: Multi-scenario datasheet did not contain per-row ScenarioId. 
+                          This sheet must be exported per scenario to preserve row identity.")
+                }
+
+            } else if (sqlStatement$select == "SELECT *") {
+                sheet[[cRow$name]] <- NA
+            } else {
+                next
+            }
         }
         
         outNames <- c(outNames, cRow$name)

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -606,11 +606,16 @@ setMethod("datasheet",
       # Policy change - always query output directly from database. It is faster.
       useConsole <- useConsole & ((sqlStatement$select == "SELECT *")) # &(!lookupsAsFactors))
       useConsole <- useConsole & !((sheetNames$scope == "project") & (length(pid) > 1))
-      # Force DB query for multi-scenario sheets (console export loses ScenarioId!)
+      # --------------------------------------------
+      # Enforce DB query for multi-scenario OR multi-project
+      # --------------------------------------------
+
       if (sheetNames$scope == "scenario" && length(sid) > 1) {
           useConsole <- FALSE
-      } else {
-          useConsole <- TRUE
+      }
+
+      if (sheetNames$scope == "project" && length(pid) > 1) {
+          useConsole <- FALSE
       }
       # => These send you to query building (case for BOTH fastQuery and UseConsole are FALSE) if :
       # sql statement is complex, or more than one proj/sce is provided
@@ -1102,16 +1107,15 @@ setMethod("datasheet",
       }
     }
     
-    if (is.element("ProjectId", names(sheet))) {
-      if (length(pid) == 1) {
-        sheet$ProjectId <- NULL
-      } else {
-        if (nrow(sheet) > 0) {
-          allProjects <- .project(x)
-          names(allProjects) <- c("ProjectId", "ProjectName")
-          sheet <- merge(allProjects, sheet, all.y = TRUE)
+    if ("ProjectId" %in% names(sheet)) {
+
+        # Single project extraction → simplify output
+        if (length(pid) == 1) {
+            sheet$ProjectId <- NULL
         }
-      }
+
+        # Multi-project: keep ProjectId exactly as returned by DB
+        # DO NOT modify or rebuild it (DB output is correct)
     }
     if (is.element("ScenarioId", names(sheet))) {
 

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -191,8 +191,6 @@ setMethod("datasheet",
                    filterColumn, filterValue, lookupsAsFactors, sqlStatement, 
                    includeKey, forceElements, fastQuery, returnScenarioInfo,
                    returnInvisible, rawValues, verbose) {
-  
-  print("=== In datasheet method for list ===")
 
   cScn <- ssimObject[[1]]
   x <- NULL
@@ -256,21 +254,9 @@ setMethod("datasheet",
   xProjScn <- .getFromXProjScn(ssimObject, project, scenario, returnIds = TRUE, 
                                convertObject = FALSE, complainIfMissing = TRUE)
 
-  print("=== In datasheet method for SsimObject ===")
-  print("=== After .getFromXProjScn ===")
-
   IDColumns <- c("ScenarioId", "ProjectId")
   
-  # -------------------------------------------------------------------------
-  # NEW: Goal-based scope detection (fixes multi-scenario logic)
-  # -------------------------------------------------------------------------
-
-  # xProjScn always contains:
-  #   $ssimObject
-  #   $project
-  #   $scenario
-  #   $scenarioSet
-  #   $goal  ← THIS is the correct source of truth
+  # Goal-based scope detection (fixes multi-scenario logic)
 
   scopeDS <- xProjScn$goal
   x <- NULL
@@ -294,19 +280,11 @@ setMethod("datasheet",
       }
   }
 
-  cat("DEBUG: Goal-based initialization\n")
-  print(list(goal = scopeDS, pid = pid, sid = sid))
-
-  # -------------------------------------------------------------------------
   # Override using scenarioSet (handles lists and multi-scenario inputs)
-  # -------------------------------------------------------------------------
 
   if (!is.null(xProjScn$scenarioSet)) {
 
       scenarioSet <- xProjScn$scenarioSet
-
-      cat("DEBUG: scenarioSet detected\n")
-      print(head(scenarioSet))
 
       # If user did not explicitly specify scenarios, derive them
       if (is.null(scenario)) {
@@ -314,24 +292,18 @@ setMethod("datasheet",
           pid <- unique(scenarioSet$ProjectId)
       }
 
-      # MULTI-SCENARIO → enforce scenario scope
+      # enforce scenario scope for multi-scenario input
       if (length(unique(scenarioSet$ScenarioId)) > 1) {
           scopeDS <- "scenario"
           returnScenarioInfo <- TRUE
-          cat("DEBUG: Multi-scenario override triggered\n")
       }
 
-      # MULTI-PROJECT but not multi-scenario
+      # enforce project scope for multi-project input
       if (length(unique(scenarioSet$ProjectId)) > 1 &&
           length(unique(scenarioSet$ScenarioId)) == 1) {
           scopeDS <- "project"
-          cat("DEBUG: Multi-project override triggered\n")
       }
   }
-
-  # -------------------------------------------------------------------------
-  # Respect explicit scenario / project arguments
-  # -------------------------------------------------------------------------
 
   # Explicit scenario override
   if (!missing(scenario) && !is.null(scenario)) {
@@ -349,10 +321,6 @@ setMethod("datasheet",
           scopeDS <- "project"
       }
   }
-
-  cat("DEBUG: Final pid/sid/scope after overrides:\n")
-  print(list(scope = scopeDS, pid = pid, sid = sid))
-  # -------------------------------------------------------------------------
   
   # now have valid pid/sid vectors and x is library.
   if (!is.null(name)) {
@@ -485,9 +453,6 @@ setMethod("datasheet",
   
   # Loop through all datasheet names
   for (kk in seq(length.out = length(allNames))) {
-
-    cat("\n=== Processing sheet:", name, "===\n")
-    print(list(pid = pid, sid = sid, sheetScope = scopeDS))
     
     if (summary == FALSE) {
       
@@ -606,10 +571,8 @@ setMethod("datasheet",
       # Policy change - always query output directly from database. It is faster.
       useConsole <- useConsole & ((sqlStatement$select == "SELECT *")) # &(!lookupsAsFactors))
       useConsole <- useConsole & !((sheetNames$scope == "project") & (length(pid) > 1))
-      # --------------------------------------------
-      # Enforce DB query for multi-scenario OR multi-project
-      # --------------------------------------------
 
+      # Enforce DB query for multi-scenario OR multi-project
       if (sheetNames$scope == "scenario" && length(sid) > 1) {
           useConsole <- FALSE
       }
@@ -765,11 +728,8 @@ setMethod("datasheet",
               stop(tt)
             }
 
-            cat("CONSOLE EXPORT path\n")
-
             sheet <- read.csv(tempFile, as.is = TRUE, encoding = "UTF-8")
             
-            cat("Rows/Cols after import:", nrow(sheet), ncol(sheet), "\n")
           }
         }
         
@@ -820,10 +780,7 @@ setMethod("datasheet",
         # Normalize DB column names to expected SyncroSim case conventions
         names(sheet) <- sub("^ScenarioID$", "ScenarioId", names(sheet), ignore.case = TRUE)
         names(sheet) <- sub("^ProjectID$",  "ProjectId", names(sheet), ignore.case = TRUE)
-        cat("DB query path: columns = ", paste(names(sheet), collapse=", "), "\n")
         DBI::dbDisconnect(con)
-
-        cat("Rows/Cols after import:", nrow(sheet), ncol(sheet), "\n")
         
         # Filter out columns without data (drop NA columns) 
         if (!optional && (nrow(sheet) > 0)) {
@@ -899,19 +856,8 @@ setMethod("datasheet",
       for (i in seq(length.out = nrow(sheetInfo))) {
 
         cRow <- sheetInfo[i, ]
-
-        if (cRow$name == "ScenarioId") {
-          cat("*** About to assign ScenarioId ***\n")
-          print(list(
-            sid = sid,
-            sheet_nrows = nrow(sheet),
-            existing_col = sheet[["ScenarioId"]]
-          ))
-        }
         
-        # ------------------------------
-        # ScenarioId Handling (correct)
-        # ------------------------------
+        # ScenarioId Handling
         if (cRow$name == "ScenarioId") {
 
             # DB query path (multi or single scenario)
@@ -931,7 +877,7 @@ setMethod("datasheet",
             }
 
             # Console export: single scenario
-            # Console output missing ScenarioId → fill with scalar sid
+            # Console output missing ScenarioId; fill with scalar sid
             if (length(sid) == 1) {
                 sheet$ScenarioId <- rep(sid, nrow(sheet))
                 outNames <- c(outNames, "ScenarioId")
@@ -945,10 +891,7 @@ setMethod("datasheet",
         }
 
 
-        # ------------------------------
         # Non-ScenarioId handling
-        # Only fill missing columns when needed
-        # ------------------------------
         if (!is.element(cRow$name, colnames(sheet))) {
 
             # For SELECT * queries, missing columns become NA
@@ -958,7 +901,6 @@ setMethod("datasheet",
                 next
             }
 
-            # Otherwise skip; column to be ignored
             next
         }
 
@@ -1118,9 +1060,6 @@ setMethod("datasheet",
         # DO NOT modify or rebuild it (DB output is correct)
     }
     if (is.element("ScenarioId", names(sheet))) {
-
-      cat("ScenarioId handling block: before merge\n")
-      print(head(sheet))
 
       if (length(sid) > 1){
         returnScenarioInfo <- TRUE


### PR DESCRIPTION
* Fixed duplicated rows in datasheet output for multi-scenario and multi-project requests
* Updated datasheet function to handle list and vector inputs for multi-scenario and multi-project requests
* Multi-scenario and multi-project requests now always use a DB query instead of console export, ensuring ScenarioId and ProjectId are returned correctly