### PR TITLE
Fix for datasheet grabbing wrong ID casing

### DIFF
--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -968,7 +968,6 @@ setMethod(
         sheet[sheet == ""] <- NA
       }
 
-      browser()
       # standardize ID columns
       names(sheet) <- sub("ID$", "Id", names(sheet))
 

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -968,6 +968,7 @@ setMethod(
         sheet[sheet == ""] <- NA
       }
 
+      browser()
       # standardize ID columns
       names(sheet) <- sub("ID$", "Id", names(sheet))
 
@@ -1108,9 +1109,14 @@ setMethod(
 
         for (i in seq(length.out = nrow(sheetInfo))) {
           cRow <- sheetInfo[i, ]
-
-          if (!is.element(cRow$name, colnames(sheet))) {
-            if (cRow$name == "ScenarioId") {
+          
+          sheetColnames <- colnames(sheet)
+          if (!is.element(cRow$name, sheetColnames)) {
+            if (is.element(tolower(cRow$name), tolower(sheetColnames))) {
+              matchIdx <- match(tolower(cRow$name), tolower(sheetColnames))
+              sheetColnames[matchIdx] <- cRow$name
+              colnames(sheet) <- sheetColnames
+            } else if (cRow$name == "ScenarioId") {
               sheet[[cRow$name]] <- sid
             } else if (sqlStatement$select == "SELECT *") {
               sheet[[cRow$name]] <- NA

--- a/R/datasheet.R
+++ b/R/datasheet.R
@@ -967,9 +967,44 @@ setMethod(
       if (nrow(sheet) > 0) {
         sheet[sheet == ""] <- NA
       }
+      
+      # standardize primary key and foreign key ID columns only (not all ID columns)
+      # Get column properties to identify primary keys and foreign keys
+      args <- list(
+        list = NULL,
+        columns = NULL,
+        allprops = NULL,
+        csv = NULL,
+        lib = .filepath(x),
+        sheet = name
+      )
+      tt <- command(args, session = session(x))
+      cPropsAll <- .dataframeFromSSim(tt)
 
-      # standardize ID columns
-      names(sheet) <- sub("ID$", "Id", names(sheet))
+      # Identify columns that should be converted:
+      # 1. Primary key columns (isPrimary=Yes)
+      # 2. Foreign key columns (valType=DataSheet)
+      primaryKeyCols <- cPropsAll[
+        grep("isPrimary^Yes", cPropsAll$properties, fixed = TRUE),
+      ]$name
+
+      foreignKeyCols <- cPropsAll[cPropsAll$valType == "DataSheet", ]$name
+
+      # Combine primary and foreign key columns
+      colsToConvert <- unique(c(primaryKeyCols, foreignKeyCols))
+
+      # Only convert these columns from "ID" to "Id"
+      for (colName in colsToConvert) {
+        # Check if this column ends with "ID" (uppercase)
+        if (grepl("ID$", colName)) {
+          # Convert "ID" to "Id" for this column
+          newColName <- sub("ID$", "Id", colName)
+          # Rename in the sheet if it exists
+          if (colName %in% names(sheet)) {
+            names(sheet)[names(sheet) == colName] <- newColName
+          }
+        }
+      }
 
       # Apply post-filtering if there are multiple scenarios and filtering was requested
       if (
@@ -1109,13 +1144,8 @@ setMethod(
         for (i in seq(length.out = nrow(sheetInfo))) {
           cRow <- sheetInfo[i, ]
           
-          sheetColnames <- colnames(sheet)
-          if (!is.element(cRow$name, sheetColnames)) {
-            if (is.element(tolower(cRow$name), tolower(sheetColnames))) {
-              matchIdx <- match(tolower(cRow$name), tolower(sheetColnames))
-              sheetColnames[matchIdx] <- cRow$name
-              colnames(sheet) <- sheetColnames
-            } else if (cRow$name == "ScenarioId") {
+          if (!is.element(cRow$name, colnames(sheet))) {
+            if (cRow$name == "ScenarioId") {
               sheet[[cRow$name]] <- sid
             } else if (sqlStatement$select == "SELECT *") {
               sheet[[cRow$name]] <- NA
@@ -1200,7 +1230,45 @@ setMethod(
                   lookupSheet <- read.csv(lookupPath, as.is = TRUE)
                 }
               }
-              names(lookupSheet) <- sub("ID$", "Id", names(lookupSheet))
+
+              # standardize primary key and foreign key ID columns only (not all ID columns)
+              # Get column properties for the lookup datasheet
+              argsLookup <- list(
+                list = NULL,
+                columns = NULL,
+                allprops = NULL,
+                csv = NULL,
+                lib = .filepath(x),
+                sheet = cRow$formula1
+              )
+              ttLookup <- command(argsLookup, session = session(x))
+              cPropsLookup <- .dataframeFromSSim(ttLookup)
+
+              # Identify columns that should be converted in lookup sheet:
+              # 1. Primary key columns (isPrimary=Yes)
+              # 2. Foreign key columns (valType=DataSheet)
+              primaryKeyColsLookup <- cPropsLookup[
+                grep("isPrimary^Yes", cPropsLookup$properties, fixed = TRUE),
+              ]$name
+
+              foreignKeyColsLookup <- cPropsLookup[cPropsLookup$valType == "DataSheet", ]$name
+
+              # Combine primary and foreign key columns
+              colsToConvertLookup <- unique(c(primaryKeyColsLookup, foreignKeyColsLookup))
+
+              # Only convert these columns from "ID" to "Id"
+              for (colName in colsToConvertLookup) {
+                # Check if this column ends with "ID" (uppercase)
+                if (grepl("ID$", colName)) {
+                  # Convert "ID" to "Id" for this column
+                  newColName <- sub("ID$", "Id", colName)
+                  # Rename in the lookup sheet if it exists
+                  if (colName %in% names(lookupSheet)) {
+                    names(lookupSheet)[names(lookupSheet) == colName] <- newColName
+                  }
+                }
+              }
+
               if (is.element("ProjectId", names(lookupSheet))) {
                 if (identical(pid, NULL) & !identical(sid, NULL)) {
                   allScns <- scenario(x)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column matching when populating datasheets to treat column names case-insensitively, reducing mismatches.
  * When a case-insensitive match is found, sheet column names are aligned to the canonical names for consistent output.
  * Preserved previous behaviors for ID assignment and full-selection imports to maintain compatibility.
  * Restrict renaming of "ID"→"Id" to primary key and foreign key columns only, avoiding unintended renames in other columns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->